### PR TITLE
Feature: Support for non form controls

### DIFF
--- a/src/BootstrapRenderer.php
+++ b/src/BootstrapRenderer.php
@@ -14,6 +14,7 @@ use Nette\Forms\Controls\BaseControl;
 use Nette\Forms\Form;
 use Nette\Forms\FormRenderer;
 use Nette\Utils\Html;
+use Contributte\FormsBootstrap\Controls\CustomControl;
 
 /**
  * Converts a Form into Bootstrap 4 HTML output.
@@ -468,15 +469,20 @@ class BootstrapRenderer implements FormRenderer
 				continue;
 			}
 
-			if ($control instanceof BootstrapRow) {
+			if ($control instanceof CustomControl) {
 				$html->addHtml($control->render());
 			} else {
 				if ($control->getOption(RendererOptions::TYPE) === 'hidden') {
 					$isHidden = true;
 					$pairHtml = $this->renderControl($control);
 				} else {
-					$pairHtml = $this->renderPair($control);
-					$isHidden = false;
+				    if ($control->getOption(RendererOptions::ONLY_CONTROL) === true) {
+				        $pairHtml = $this->renderControl($control);
+				        $isHidden = false;
+				    } else {
+    					$pairHtml = $this->renderPair($control);
+    					$isHidden = false;
+				    }
 				}
 
 				if ($this->groupHidden && $isHidden) {

--- a/src/BootstrapRenderer.php
+++ b/src/BootstrapRenderer.php
@@ -2,11 +2,11 @@
 
 namespace Contributte\FormsBootstrap;
 
+use Contributte\FormsBootstrap\Controls\CustomControl;
 use Contributte\FormsBootstrap\Enums\BootstrapVersion;
 use Contributte\FormsBootstrap\Enums\RendererConfig as Cnf;
 use Contributte\FormsBootstrap\Enums\RendererOptions;
 use Contributte\FormsBootstrap\Enums\RenderMode;
-use Contributte\FormsBootstrap\Grid\BootstrapRow;
 use Contributte\FormsBootstrap\Inputs\IValidationInput;
 use Nette;
 use Nette\Forms\Control;
@@ -14,7 +14,6 @@ use Nette\Forms\Controls\BaseControl;
 use Nette\Forms\Form;
 use Nette\Forms\FormRenderer;
 use Nette\Utils\Html;
-use Contributte\FormsBootstrap\Controls\CustomControl;
 
 /**
  * Converts a Form into Bootstrap 4 HTML output.

--- a/src/Controls/CustomControl.php
+++ b/src/Controls/CustomControl.php
@@ -1,0 +1,119 @@
+<?php declare(strict_types = 1);
+
+namespace Contributte\FormsBootstrap\Controls;
+
+use Contributte\FormsBootstrap\Traits\FakeControlTrait;
+use Nette\ComponentModel\IComponent;
+use Nette\ComponentModel\IContainer;
+use Nette\Forms\Container;
+use Nette\Forms\Control;
+use Nette\SmartObject;
+
+abstract class CustomControl implements IComponent, Control
+{
+    
+    use SmartObject;
+    use FakeControlTrait;
+    
+    /**
+     * Form or container this belong to
+     *
+     * @var Container
+     */
+    private $container;
+    
+    /** @var string */
+    private $name;
+    
+    /** @var mixed[] */
+    private $options = [];
+    
+    /**
+     * 
+     * @return IContainer|NULL
+     */
+    public function getContainer(): ?IContainer {
+        return $this->container;
+    }
+    
+    /**
+     * 
+     * @param IContainer $container
+     */
+    public function setContainer(IContainer $container): void {
+        $this->container = $container;
+    }
+    
+    /**
+     * Returns component name
+     */
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+    
+    /**
+     * Sets component name
+     * 
+     * @param string $name
+     */
+    public function setName(string $name): void {
+        $this->name = $name;
+    }
+    
+    /**
+     * Returns the container
+     *
+     * @return Container
+     */
+    public function getParent(): IContainer
+    {
+        return $this->container;
+    }
+    
+    /**
+     * Sets the container
+     *
+     * @param Container|NULL $parent
+     * @param null $name ignored
+     */
+    public function setParent(?IContainer $parent = null, ?string $name = null): IComponent
+    {
+        $this->container = $parent;
+        
+        return $this;
+    }
+    
+    /**
+     * Gets previously set option
+     *
+     * @param mixed|null $default
+     * @return mixed|null
+     */
+    public function getOption(string $option, $default = null)
+    {
+        return $this->options[$option] ?? $default;
+    }
+    
+    /**
+     * Sets option
+     *
+     * @param mixed|null $value
+     * @internal
+     */
+    public function setOption(string $option, $value): void
+    {
+        $this->options[$option] = $value;
+    }
+    
+    /**
+     * Delegate to underlying container and remember it.
+     *
+     * @internal
+     */
+    public function addComponent(IComponent $component, ?string $name = null, ?string $insertBefore = null): void
+    {
+        $this->container->addComponent($component, $name, $insertBefore);
+    }
+    
+}

--- a/src/Controls/CustomControl.php
+++ b/src/Controls/CustomControl.php
@@ -1,5 +1,6 @@
-<?php declare(strict_types = 1);
+<?php
 
+declare(strict_types = 1);
 namespace Contributte\FormsBootstrap\Controls;
 
 use Contributte\FormsBootstrap\Traits\FakeControlTrait;
@@ -11,109 +12,115 @@ use Nette\SmartObject;
 
 abstract class CustomControl implements IComponent, Control
 {
-    
-    use SmartObject;
-    use FakeControlTrait;
-    
-    /**
-     * Form or container this belong to
-     *
-     * @var Container
-     */
-    private $container;
-    
-    /** @var string */
-    private $name;
-    
-    /** @var mixed[] */
-    private $options = [];
-    
-    /**
-     * 
-     * @return IContainer|NULL
-     */
-    public function getContainer(): ?IContainer {
-        return $this->container;
-    }
-    
-    /**
-     * 
-     * @param IContainer $container
-     */
-    public function setContainer(IContainer $container): void {
-        $this->container = $container;
-    }
-    
-    /**
-     * Returns component name
-     */
-    public function getName(): ?string
-    {
-        return $this->name;
-    }
-    
-    /**
-     * Sets component name
-     * 
-     * @param string $name
-     */
-    public function setName(string $name): void {
-        $this->name = $name;
-    }
-    
-    /**
-     * Returns the container
-     *
-     * @return Container
-     */
-    public function getParent(): IContainer
-    {
-        return $this->container;
-    }
-    
-    /**
-     * Sets the container
-     *
-     * @param Container|NULL $parent
-     * @param null $name ignored
-     */
-    public function setParent(?IContainer $parent = null, ?string $name = null): IComponent
-    {
-        $this->container = $parent;
-        
-        return $this;
-    }
-    
-    /**
-     * Gets previously set option
-     *
-     * @param mixed|null $default
-     * @return mixed|null
-     */
-    public function getOption(string $option, $default = null)
-    {
-        return $this->options[$option] ?? $default;
-    }
-    
-    /**
-     * Sets option
-     *
-     * @param mixed|null $value
-     * @internal
-     */
-    public function setOption(string $option, $value): void
-    {
-        $this->options[$option] = $value;
-    }
-    
-    /**
-     * Delegate to underlying container and remember it.
-     *
-     * @internal
-     */
-    public function addComponent(IComponent $component, ?string $name = null, ?string $insertBefore = null): void
-    {
-        $this->container->addComponent($component, $name, $insertBefore);
-    }
-    
+
+	use SmartObject;
+	use FakeControlTrait;
+
+	/**
+	 * Form or container this belong to
+	 *
+	 * @var Container
+	 */
+	private $container;
+
+	/** @var string */
+	private $name;
+
+	/** @var mixed[] */
+	private $options = [];
+
+	/**
+	 *
+	 * @return Container|NULL
+	 */
+	public function getContainer(): ?Container
+	{
+		return $this->container;
+	}
+
+	/**
+	 *
+	 * @param Container $container
+	 */
+	public function setContainer(Container $container): void
+	{
+		$this->container = $container;
+	}
+
+	/**
+	 * Returns component name
+	 */
+	public function getName(): ?string
+	{
+		return $this->name;
+	}
+
+	/**
+	 * Sets component name
+	 *
+	 * @param string $name
+	 */
+	public function setName(string $name): void
+	{
+		$this->name = $name;
+	}
+
+	/**
+	 * Returns the container
+	 *
+	 * @return Container
+	 */
+	public function getParent(): IContainer
+	{
+		return $this->container;
+	}
+
+	/**
+	 * Sets the container
+	 *
+	 * @param Container|NULL $parent
+	 * @param null $name
+	 *        	ignored
+	 */
+	public function setParent(?IContainer $parent = null, ?string $name = null): IComponent
+	{
+		$this->container = $parent;
+
+		return $this;
+	}
+
+	/**
+	 * Gets previously set option
+	 *
+	 * @param mixed|null $default
+	 * @return mixed|null
+	 */
+	public function getOption(string $option, $default = null)
+	{
+		return $this->options[$option] ?? $default;
+	}
+
+	/**
+	 * Sets option
+	 *
+	 * @param mixed|null $value
+	 * @internal
+	 */
+	public function setOption(string $option, $value): void
+	{
+		$this->options[$option] = $value;
+	}
+
+	/**
+	 * Delegate to underlying container and remember it.
+	 *
+	 * @internal
+	 */
+	public function addComponent(IComponent $component, ?string $name = null, ?string $insertBefore = null): void
+	{
+		$this->container->addComponent($component, $name, $insertBefore);
+	}
+
+	abstract public function render();
+
 }

--- a/src/Enums/RendererOptions.php
+++ b/src/Enums/RendererOptions.php
@@ -48,5 +48,9 @@ class RendererOptions
 	 * shown instead of an error
 	 */
 	public const FEEDBACK_VALID = 'feedback-valid';
+	/**
+	 * Boolean. Can be set on control, if true control will be rendered only by BootstrapRenderer->renderControl().
+	 */
+	public const ONLY_CONTROL = 'only-control';
 
 }

--- a/src/Grid/BootstrapRow.php
+++ b/src/Grid/BootstrapRow.php
@@ -1,168 +1,173 @@
-<?php declare(strict_types = 1);
+<?php
 
+declare(strict_types = 1);
 namespace Contributte\FormsBootstrap\Grid;
 
 use Contributte\FormsBootstrap\BootstrapRenderer;
+use Contributte\FormsBootstrap\Controls\CustomControl;
 use Contributte\FormsBootstrap\Enums\RendererConfig;
 use Contributte\FormsBootstrap\Enums\RendererOptions;
 use Nette\ComponentModel\IComponent;
 use Nette\Forms\Container;
 use Nette\InvalidArgumentException;
 use Nette\Utils\Html;
-use Contributte\FormsBootstrap\Controls\CustomControl;
 
 /**
  * Class BootstrapRow.
  * Represents a row in Bootstrap grid system.
  *
- * @property string               $gridBreakPoint   Bootstrap breakpoint - usually xs, sm, md, lg. sm by
+ * @property string $gridBreakPoint Bootstrap breakpoint - usually xs, sm, md, lg. sm by
  *           default. Use NULL for no breakpoint.
- * @property-read string[]        $ownedNames       list of names of components which were added to this row
- * @property-read BootstrapCell[] $cells            cells in this row
- * @property-read Html            $elementPrototype the Html div that will be rendered. You may define
+ * @property-read string[] $ownedNames list of names of components which were added to this row
+ * @property-read BootstrapCell[] $cells cells in this row
+ * @property-read Html $elementPrototype the Html div that will be rendered. You may define
  *                additional properties.
- * @property-read string          $name             name of component
+ * @property-read string $name name of component
  */
 class BootstrapRow extends CustomControl
 {
-    
-    /**
-     * Global name counter
-     *
-     * @var int
-     */
-    private static $uidCounter = 0;
-    
-    /**
-     * Number of columns in Bootstrap grid. Default is 12, but it can be customized.
-     *
-     * @var int
-     */
-    public $numOfColumns = 12;
-    
-    /**
-     * Number of columns used by added cells.
-     *
-     * @var int
-     */
-    private $columnsOccupied = 0;
-    
-    /** @var string */
-    private $gridBreakPoint = 'sm';
-    
-    /** @var string[] */
-    private $ownedNames = [];
-    
-    /** @var BootstrapCell[] */
-    private $cells = [];
-    
-    /** @var Html */
-    private $elementPrototype;
-    
-    /**
-     * @param Container $container Form or container this belongs to. Components will be added to this
-     * @param string|null      $name      Optional name of this row. If none is supplied, it is generated
-     *                             automatically.
-     */
-    public function __construct(Container $container, $name = null)
-    {
-        $this->setContainer($container);
-        if (!$name) {
-            $name = 'bootstrap_row_' . ++self::$uidCounter;
-        }
-        
-        $this->setName($name);
-        
-        $this->elementPrototype = Html::el();
-    }
-    
-    /**
-     * Adds a new cell to which a control can be added.
-     */
-    public function addCell(int $numOfColumns = BootstrapCell::COLUMNS_NONE): BootstrapCell
-    {
-        if ($this->columnsOccupied + $numOfColumns > $this->numOfColumns) {
-            throw new InvalidArgumentException(
-                'the given number of columns with combination of already used'
-                . ' columns exceeds column limit (' . $this->numOfColumns . ')'
-                );
-        }
-        
-        $cell = new BootstrapCell($this, $numOfColumns);
-        $this->cells[] = $cell;
-        
-        return $cell;
-    }
-    
-    /**
-     * Delegate to underlying container and remember it.
-     *
-     * @internal
-     */
-    public function addComponent(IComponent $component, ?string $name = null, ?string $insertBefore = null): void
-    {
-        parent::addComponent($component, $name, $insertBefore);
-        $this->ownedNames[] = $name;
-    }
-    
-    /**
-     * @return BootstrapCell[]
-     * @see BootstrapRow::$cells
-     */
-    public function getCells(): array
-    {
-        return $this->cells;
-    }
-    
-    /**
-     * The container without content
-     *
-     * @see BootstrapRow::$elementPrototype
-     */
-    public function getElementPrototype(): Html
-    {
-        return $this->elementPrototype;
-    }
-    
-    /**
-     * @see BootstrapRow::$gridBreakPoint
-     */
-    public function getGridBreakPoint(): string
-    {
-        return $this->gridBreakPoint;
-    }
-    
-    /**
-     * Sets the xs, sm, md, lg part.
-     *
-     * @see BootstrapRow::$gridBreakPoint
-     * @param string $gridBreakPoint . NULL for no breakpoint.
-     */
-    public function setGridBreakPoint(string $gridBreakPoint): BootstrapRow
-    {
-        $this->gridBreakPoint = $gridBreakPoint;
-        
-        return $this;
-    }
-        
-    /**
-     * Renders the row into a Html object
-     */
-    public function render(): Html
-    {
-        /** @var BootstrapRenderer $renderer */
-        $renderer = $this->getContainer()->form->renderer;
-        
-        $element = $renderer->configElem(RendererConfig::GRID_ROW, $this->elementPrototype);
-        
-        foreach ($this->cells as $cell) {
-            $cellHtml = $cell->render();
-            $element->addHtml($cellHtml);
-        }
-        
-        $this->setOption(RendererOptions::_RENDERED, true);
-        
-        return $element;
-    }
-    
+	
+	/**
+	 * Global name counter
+	 *
+	 * @var int
+	 */
+	private static $uidCounter = 0;
+
+	/**
+	 * Number of columns in Bootstrap grid.
+	 * Default is 12, but it can be customized.
+	 *
+	 * @var int
+	 */
+	public $numOfColumns = 12;
+
+	/**
+	 * Number of columns used by added cells.
+	 *
+	 * @var int
+	 */
+	private $columnsOccupied = 0;
+
+	/** @var string */
+	private $gridBreakPoint = 'sm';
+
+	/** @var string[] */
+	private $ownedNames = [];
+
+	/** @var BootstrapCell[] */
+	private $cells = [];
+
+	/** @var Html */
+	private $elementPrototype;
+
+	/**
+	 *
+	 * @param Container $container
+	 *        	Form or container this belongs to. Components will be added to this
+	 * @param string|null $name
+	 *        	Optional name of this row. If none is supplied, it is generated
+	 *        	automatically.
+	 */
+	public function __construct(Container $container, $name = null)
+	{
+		$this->setContainer($container);
+		if (! $name) {
+			$name = 'bootstrap_row_' . ++ self::$uidCounter;
+		}
+
+		$this->setName($name);
+
+		$this->elementPrototype = Html::el();
+	}
+
+	/**
+	 * Adds a new cell to which a control can be added.
+	 */
+	public function addCell(int $numOfColumns = BootstrapCell::COLUMNS_NONE): BootstrapCell
+	{
+		if ($this->columnsOccupied + $numOfColumns > $this->numOfColumns) {
+			throw new InvalidArgumentException('the given number of columns with combination of already used' . ' columns exceeds column limit (' . $this->numOfColumns . ')');
+		}
+
+		$cell = new BootstrapCell($this, $numOfColumns);
+		$this->cells[] = $cell;
+
+		return $cell;
+	}
+
+	/**
+	 * Delegate to underlying container and remember it.
+	 *
+	 * @internal
+	 */
+	public function addComponent(IComponent $component, ?string $name = null, ?string $insertBefore = null): void
+	{
+		parent::addComponent($component, $name, $insertBefore);
+		$this->ownedNames[] = $name;
+	}
+
+	/**
+	 *
+	 * @return BootstrapCell[]
+	 * @see BootstrapRow::$cells
+	 */
+	public function getCells(): array
+	{
+		return $this->cells;
+	}
+
+	/**
+	 * The container without content
+	 *
+	 * @see BootstrapRow::$elementPrototype
+	 */
+	public function getElementPrototype(): Html
+	{
+		return $this->elementPrototype;
+	}
+
+	/**
+	 *
+	 * @see BootstrapRow::$gridBreakPoint
+	 */
+	public function getGridBreakPoint(): string
+	{
+		return $this->gridBreakPoint;
+	}
+
+	/**
+	 * Sets the xs, sm, md, lg part.
+	 *
+	 * @see BootstrapRow::$gridBreakPoint
+	 * @param string $gridBreakPoint
+	 *        	. NULL for no breakpoint.
+	 */
+	public function setGridBreakPoint(string $gridBreakPoint): BootstrapRow
+	{
+		$this->gridBreakPoint = $gridBreakPoint;
+
+		return $this;
+	}
+
+	/**
+	 * Renders the row into a Html object
+	 */
+	public function render(): Html
+	{
+		/** @var BootstrapRenderer $renderer */
+		$renderer = $this->getContainer()->form->renderer;
+
+		$element = $renderer->configElem(RendererConfig::GRID_ROW, $this->elementPrototype);
+
+		foreach ($this->cells as $cell) {
+			$cellHtml = $cell->render();
+			$element->addHtml($cellHtml);
+		}
+
+		$this->setOption(RendererOptions::_RENDERED, true);
+
+		return $element;
+	}
+
 }

--- a/src/Grid/BootstrapRow.php
+++ b/src/Grid/BootstrapRow.php
@@ -5,14 +5,11 @@ namespace Contributte\FormsBootstrap\Grid;
 use Contributte\FormsBootstrap\BootstrapRenderer;
 use Contributte\FormsBootstrap\Enums\RendererConfig;
 use Contributte\FormsBootstrap\Enums\RendererOptions;
-use Contributte\FormsBootstrap\Traits\FakeControlTrait;
 use Nette\ComponentModel\IComponent;
-use Nette\ComponentModel\IContainer;
 use Nette\Forms\Container;
-use Nette\Forms\Control;
 use Nette\InvalidArgumentException;
-use Nette\SmartObject;
 use Nette\Utils\Html;
+use Contributte\FormsBootstrap\Controls\CustomControl;
 
 /**
  * Class BootstrapRow.
@@ -26,214 +23,146 @@ use Nette\Utils\Html;
  *                additional properties.
  * @property-read string          $name             name of component
  */
-class BootstrapRow implements IComponent, Control
+class BootstrapRow extends CustomControl
 {
-
-	use SmartObject;
-	use FakeControlTrait;
-
-	/**
-	 * Global name counter
-	 *
-	 * @var int
-	 */
-	private static $uidCounter = 0;
-
-	/**
-	 * Number of columns in Bootstrap grid. Default is 12, but it can be customized.
-	 *
-	 * @var int
-	 */
-	public $numOfColumns = 12;
-
-	/** @var string $name */
-	private $name;
-
-	/**
-	 * Number of columns used by added cells.
-	 *
-	 * @var int
-	 */
-	private $columnsOccupied = 0;
-
-	/**
-	 * Form or container this belong to
-	 *
-	 * @var Container
-	 */
-	private $container;
-
-	/** @var string */
-	private $gridBreakPoint = 'sm';
-
-	/** @var string[] */
-	private $ownedNames = [];
-
-	/** @var BootstrapCell[] */
-	private $cells = [];
-
-	/** @var Html */
-	private $elementPrototype;
-
-	/** @var mixed[] */
-	private $options = [];
-
-	/**
-	 * @param Container $container Form or container this belongs to. Components will be added to this
-	 * @param string|null      $name      Optional name of this row. If none is supplied, it is generated
-	 *                             automatically.
-	 */
-	public function __construct(Container $container, $name = null)
-	{
-		$this->container = $container;
-		if (!$name) {
-			$name = 'bootstrap_row_' . ++self::$uidCounter;
-		}
-
-		$this->name = $name;
-
-		$this->elementPrototype = Html::el();
-	}
-
-	/**
-	 * Adds a new cell to which a control can be added.
-	 */
-	public function addCell(int $numOfColumns = BootstrapCell::COLUMNS_NONE): BootstrapCell
-	{
-		if ($this->columnsOccupied + $numOfColumns > $this->numOfColumns) {
-			throw new InvalidArgumentException(
-				'the given number of columns with combination of already used'
-				. ' columns exceeds column limit (' . $this->numOfColumns . ')'
-			);
-		}
-
-		$cell = new BootstrapCell($this, $numOfColumns);
-		$this->cells[] = $cell;
-
-		return $cell;
-	}
-
-	/**
-	 * Delegate to underlying container and remember it.
-	 *
-	 * @internal
-	 */
-	public function addComponent(IComponent $component, ?string $name = null, ?string $insertBefore = null): void
-	{
-		$this->container->addComponent($component, $name, $insertBefore);
-		$this->ownedNames[] = $name;
-	}
-
-	/**
-	 * @return BootstrapCell[]
-	 * @see BootstrapRow::$cells
-	 */
-	public function getCells(): array
-	{
-		return $this->cells;
-	}
-
-	/**
-	 * The container without content
-	 *
-	 * @see BootstrapRow::$elementPrototype
-	 */
-	public function getElementPrototype(): Html
-	{
-		return $this->elementPrototype;
-	}
-
-	/**
-	 * @see BootstrapRow::$gridBreakPoint
-	 */
-	public function getGridBreakPoint(): string
-	{
-		return $this->gridBreakPoint;
-	}
-
-	/**
-	 * Sets the xs, sm, md, lg part.
-	 *
-	 * @see BootstrapRow::$gridBreakPoint
-	 * @param string $gridBreakPoint . NULL for no breakpoint.
-	 */
-	public function setGridBreakPoint(string $gridBreakPoint): BootstrapRow
-	{
-		$this->gridBreakPoint = $gridBreakPoint;
-
-		return $this;
-	}
-
-	/**
-	 * Component name
-	 */
-	public function getName(): ?string
-	{
-		return $this->name;
-	}
-
-	/**
-	 * Returns the container
-	 *
-	 * @return Container
-	 */
-	public function getParent(): IContainer
-	{
-		return $this->container;
-	}
-
-	/**
-	 * Sets the container
-	 *
-	 * @param Container|NULL $parent
-	 * @param null $name ignored
-	 */
-	public function setParent(?IContainer $parent = null, ?string $name = null): IComponent
-	{
-		$this->container = $parent;
-
-		return $this;
-	}
-
-	/**
-	 * Gets previously set option
-	 *
-	 * @param mixed|null $default
-	 * @return mixed|null
-	 */
-	public function getOption(string $option, $default = null)
-	{
-		return $this->options[$option] ?? $default;
-	}
-
-	/**
-	 * Renders the row into a Html object
-	 */
-	public function render(): Html
-	{
-		/** @var BootstrapRenderer $renderer */
-		$renderer = $this->container->form->renderer;
-
-		$element = $renderer->configElem(RendererConfig::GRID_ROW, $this->elementPrototype);
-		foreach ($this->cells as $cell) {
-			$cellHtml = $cell->render();
-			$element->addHtml($cellHtml);
-		}
-
-		$this->setOption(RendererOptions::_RENDERED, true);
-
-		return $element;
-	}
-
-	/**
-	 * Sets option
-	 *
-	 * @param mixed|null $value
-	 * @internal
-	 */
-	public function setOption(string $option, $value): void
-	{
-		$this->options[$option] = $value;
-	}
-
+    
+    /**
+     * Global name counter
+     *
+     * @var int
+     */
+    private static $uidCounter = 0;
+    
+    /**
+     * Number of columns in Bootstrap grid. Default is 12, but it can be customized.
+     *
+     * @var int
+     */
+    public $numOfColumns = 12;
+    
+    /**
+     * Number of columns used by added cells.
+     *
+     * @var int
+     */
+    private $columnsOccupied = 0;
+    
+    /** @var string */
+    private $gridBreakPoint = 'sm';
+    
+    /** @var string[] */
+    private $ownedNames = [];
+    
+    /** @var BootstrapCell[] */
+    private $cells = [];
+    
+    /** @var Html */
+    private $elementPrototype;
+    
+    /**
+     * @param Container $container Form or container this belongs to. Components will be added to this
+     * @param string|null      $name      Optional name of this row. If none is supplied, it is generated
+     *                             automatically.
+     */
+    public function __construct(Container $container, $name = null)
+    {
+        $this->setContainer($container);
+        if (!$name) {
+            $name = 'bootstrap_row_' . ++self::$uidCounter;
+        }
+        
+        $this->setName($name);
+        
+        $this->elementPrototype = Html::el();
+    }
+    
+    /**
+     * Adds a new cell to which a control can be added.
+     */
+    public function addCell(int $numOfColumns = BootstrapCell::COLUMNS_NONE): BootstrapCell
+    {
+        if ($this->columnsOccupied + $numOfColumns > $this->numOfColumns) {
+            throw new InvalidArgumentException(
+                'the given number of columns with combination of already used'
+                . ' columns exceeds column limit (' . $this->numOfColumns . ')'
+                );
+        }
+        
+        $cell = new BootstrapCell($this, $numOfColumns);
+        $this->cells[] = $cell;
+        
+        return $cell;
+    }
+    
+    /**
+     * Delegate to underlying container and remember it.
+     *
+     * @internal
+     */
+    public function addComponent(IComponent $component, ?string $name = null, ?string $insertBefore = null): void
+    {
+        parent::addComponent($component, $name, $insertBefore);
+        $this->ownedNames[] = $name;
+    }
+    
+    /**
+     * @return BootstrapCell[]
+     * @see BootstrapRow::$cells
+     */
+    public function getCells(): array
+    {
+        return $this->cells;
+    }
+    
+    /**
+     * The container without content
+     *
+     * @see BootstrapRow::$elementPrototype
+     */
+    public function getElementPrototype(): Html
+    {
+        return $this->elementPrototype;
+    }
+    
+    /**
+     * @see BootstrapRow::$gridBreakPoint
+     */
+    public function getGridBreakPoint(): string
+    {
+        return $this->gridBreakPoint;
+    }
+    
+    /**
+     * Sets the xs, sm, md, lg part.
+     *
+     * @see BootstrapRow::$gridBreakPoint
+     * @param string $gridBreakPoint . NULL for no breakpoint.
+     */
+    public function setGridBreakPoint(string $gridBreakPoint): BootstrapRow
+    {
+        $this->gridBreakPoint = $gridBreakPoint;
+        
+        return $this;
+    }
+        
+    /**
+     * Renders the row into a Html object
+     */
+    public function render(): Html
+    {
+        /** @var BootstrapRenderer $renderer */
+        $renderer = $this->getContainer()->form->renderer;
+        
+        $element = $renderer->configElem(RendererConfig::GRID_ROW, $this->elementPrototype);
+        
+        foreach ($this->cells as $cell) {
+            $cellHtml = $cell->render();
+            $element->addHtml($cellHtml);
+        }
+        
+        $this->setOption(RendererOptions::_RENDERED, true);
+        
+        return $element;
+    }
+    
 }


### PR DESCRIPTION
I add new feature for support add non-form controls to form and still using render by  `{control form}`.

I thnig that the same i can do with actual solution but with this feature it is easier.

- Non-form control must extend from new class `Contributte\FormsBootstrap\Controls\CustomControl` like newly `BootstrapRow`, because on these control we need call only `$html->addHtml($control->render());` https://github.com/Pepino483/forms-bootstrap/blob/ffbf17604e64fe79c37bcb7c609b48e3631a42b2/src/BootstrapRenderer.php#L472
- New `RendererOptions::ONLY_CONTROL` that add support for render plain control without html wrapper and etc.. https://github.com/Pepino483/forms-bootstrap/blob/ffbf17604e64fe79c37bcb7c609b48e3631a42b2/src/BootstrapRenderer.php#L479
- Code is full backward compatible with master version