### PR TITLE
chore(deps): allow full range of nette/forms v3.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   ],
   "require": {
     "php": ">=7.2",
-    "nette/forms": "3.1.9",
+    "nette/forms": "~3.1.0",
     "nette/application": "^3.0"
   },
   "require-dev": {


### PR DESCRIPTION
nette/forms is stable already, there's no need to constraint to certain patch version.