### PR TITLE
BC: Compatibility with nette/forms 3.1.14

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   ],
   "require": {
     "php": ">=8.1",
-    "nette/forms": "3.1.12",
+    "nette/forms": "3.1.14",
     "nette/application": "^3.0"
   },
   "require-dev": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,12 +1,13 @@
-<phpunit bootstrap="tests/bootstrap.php" colors="true">
-    <testsuites>
-        <testsuite name="all">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="tests/bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="all">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Inputs/ColorPicker.php
+++ b/src/Inputs/ColorPicker.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types = 1);
+
+namespace Contributte\FormsBootstrap\Inputs;
+
+use Contributte\FormsBootstrap\BootstrapUtils;
+use Contributte\FormsBootstrap\Traits\StandardValidationTrait;
+use Nette\Utils\Html;
+
+class ColorPicker extends \Nette\Forms\Controls\ColorPicker
+{
+
+	use StandardValidationTrait;
+
+	public function getControl(): Html
+	{
+		$control = parent::getControl();
+		BootstrapUtils::standardizeClass($control);
+
+		$control->class[] = 'form-control';
+
+		return $control;
+	}
+
+}

--- a/src/Inputs/DateTimeControl.php
+++ b/src/Inputs/DateTimeControl.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types = 1);
+
+namespace Contributte\FormsBootstrap\Inputs;
+
+use Contributte\FormsBootstrap\BootstrapUtils;
+use Contributte\FormsBootstrap\Traits\StandardValidationTrait;
+use Nette\Utils\Html;
+
+class DateTimeControl extends \Nette\Forms\Controls\DateTimeControl
+{
+
+	use StandardValidationTrait;
+
+	public function getControl(): Html
+	{
+		$control = parent::getControl();
+		BootstrapUtils::standardizeClass($control);
+
+		$control->class[] = 'form-control';
+
+		return $control;
+	}
+
+}

--- a/src/Traits/BootstrapContainerTrait.php
+++ b/src/Traits/BootstrapContainerTrait.php
@@ -7,7 +7,9 @@ use Contributte\FormsBootstrap\BootstrapForm;
 use Contributte\FormsBootstrap\Inputs\ButtonInput;
 use Contributte\FormsBootstrap\Inputs\CheckboxInput;
 use Contributte\FormsBootstrap\Inputs\CheckboxListInput;
+use Contributte\FormsBootstrap\Inputs\ColorPicker;
 use Contributte\FormsBootstrap\Inputs\DateInput;
+use Contributte\FormsBootstrap\Inputs\DateTimeControl;
 use Contributte\FormsBootstrap\Inputs\DateTimeInput;
 use Contributte\FormsBootstrap\Inputs\MultiselectInput;
 use Contributte\FormsBootstrap\Inputs\RadioInput;
@@ -22,6 +24,8 @@ use Nette\Forms\Controls\BaseControl;
 use Nette\Forms\Controls\Button;
 use Nette\Forms\Controls\Checkbox;
 use Nette\Forms\Controls\CheckboxList;
+use Nette\Forms\Controls\ColorPicker as NetteColorPicker;
+use Nette\Forms\Controls\DateTimeControl as NetteDateTimeControl;
 use Nette\Forms\Controls\MultiSelectBox;
 use Nette\Forms\Controls\RadioList;
 use Nette\Forms\Controls\SelectBox;
@@ -101,10 +105,62 @@ trait BootstrapContainerTrait
 
 	/**
 	 * Adds a datetime input.
+	 *
+	 * @param string|null $label
 	 */
-	public function addDate(string $name, string $label): DateInput
+	public function addDate(string $name, $label = null): NetteDateTimeControl
 	{
-		$comp = new DateInput($label, null);
+		$comp = new DateTimeControl($label, NetteDateTimeControl::TypeDate);
+		$this->addComponent($comp, $name);
+
+		return $comp;
+	}
+
+	/**
+	 * Adds a datetime input.
+	 *
+	 * @param string|Html|null $label
+	 */
+	public function addDateTime(string $name, $label = null, bool $withSeconds = false): NetteDateTimeControl
+	{
+		$comp = new DateTimeControl($label, NetteDateTimeControl::TypeDateTime);
+		$this->addComponent($comp, $name);
+
+		return $comp;
+	}
+
+	/**
+	 * Adds a time input
+	 *
+	 * @param string|null $label
+	 */
+	public function addTime(string $name, $label = null, bool $withSeconds = false): NetteDateTimeControl
+	{
+		$comp = new DateTimeControl($label, NetteDateTimeControl::TypeTime);
+		$this->addComponent($comp, $name);
+
+		return $comp;
+	}
+
+	/**
+	 * Adds a color input
+	 *
+	 * @param string|null $label
+	 */
+	public function addColor(string $name, $label = null, bool $withSeconds = false): NetteColorPicker
+	{
+		$comp = new ColorPicker($label);
+		$this->addComponent($comp, $name);
+
+		return $comp;
+	}
+
+	/**
+	 * Adds a datetime input.
+	 */
+	public function addBootstrapDate(string $name, string $label): DateInput
+	{
+		$comp = new DateInput($label);
 		$comp->setNullable(BootstrapForm::$allwaysUseNullable);
 		$this->addComponent($comp, $name);
 
@@ -115,7 +171,7 @@ trait BootstrapContainerTrait
 	 * @param string|Html|null $label
 	 * Adds a datetime input.
 	 */
-	public function addDateTime(string $name, $label): DateTimeInput
+	public function addBootstrapDateTime(string $name, $label): DateTimeInput
 	{
 		$comp = new DateTimeInput($label);
 		$comp->setNullable(BootstrapForm::$allwaysUseNullable);

--- a/tests/Inputs/ColorPickerTest.php
+++ b/tests/Inputs/ColorPickerTest.php
@@ -1,0 +1,19 @@
+<?php declare (strict_types = 1);
+
+namespace Tests\Inputs;
+
+use Contributte\FormsBootstrap\BootstrapForm;
+use Tests\BaseTest;
+
+class ColorPickerTest extends BaseTest
+{
+
+	public function testDefaultTextInput(): void
+	{
+		$form = new BootstrapForm();
+		$input = $form->addColor('color', 'Choose color');
+		$this->assertEquals('<input type="color" name="color" id="frm-color" value="#000000" class="form-control">', $input->getControl()->render());
+		$this->assertEquals('<label for="frm-color">Choose color</label>', (string) $input->getLabel());
+	}
+
+}

--- a/tests/Inputs/DateInputTest.php
+++ b/tests/Inputs/DateInputTest.php
@@ -13,7 +13,7 @@ class DateInputTest extends BaseTest
 	public function testDefaultDate(): void
 	{
 		$form = new BootstrapForm();
-		$dt = $form->addDate('date', 'Date');
+		$dt = $form->addBootstrapDate('date', 'Date');
 		$this->assertEquals('<input type="text" name="date" id="frm-date" class="form-control" placeholder="d.m.yyyy (31.12.1998)">', $dt->getControl()->render());
 	}
 
@@ -21,7 +21,7 @@ class DateInputTest extends BaseTest
 	{
 		$form = new BootstrapForm();
 		DateInput::$defaultFormat = DateTimeFormat::D_YMD_DASHES;
-		$dt = $form->addDate('date', 'Date');
+		$dt = $form->addBootstrapDate('date', 'Date');
 		$this->assertEquals('<input type="text" name="date" id="frm-date" class="form-control" placeholder="yyyy-mm-dd (1998-12-31)">', $dt->getControl()->render());
 	}
 

--- a/tests/Inputs/DateTimeControlTest.php
+++ b/tests/Inputs/DateTimeControlTest.php
@@ -1,0 +1,18 @@
+<?php declare (strict_types = 1);
+
+namespace Tests\Inputs;
+
+use Contributte\FormsBootstrap\BootstrapForm;
+use Tests\BaseTest;
+
+class DateTimeControlTest extends BaseTest
+{
+
+	public function testDefaultDate(): void
+	{
+		$form = new BootstrapForm();
+		$dt = $form->addDate('date', 'Date');
+		$this->assertEquals('<input type="date" name="date" id="frm-date" class="form-control">', $dt->getControl()->render());
+	}
+
+}

--- a/tests/Inputs/DateTimeInputTest.php
+++ b/tests/Inputs/DateTimeInputTest.php
@@ -14,7 +14,7 @@ class DateTimeInputTest extends BaseTest
 	public function testDefaultDateTime(): void
 	{
 		$form = new BootstrapForm();
-		$dt = $form->addDateTime('datetime', 'Date and time');
+		$dt = $form->addBootstrapDateTime('datetime', 'Date and time');
 		$this->assertEquals('<input type="text" name="datetime" id="frm-datetime" class="form-control" placeholder="d.m.yyyy h:mm (31.12.1998 23:59)">', $dt->getControl()->render());
 	}
 
@@ -23,7 +23,7 @@ class DateTimeInputTest extends BaseTest
 		$form = new BootstrapForm();
 		DateTimeInput::$additionalHtmlClasses[] = 'datetimepicker';
 		DateTimeInput::$additionalHtmlClasses[] = 'cool';
-		$dt = $form->addDateTime('datetime', 'Date and time');
+		$dt = $form->addBootstrapDateTime('datetime', 'Date and time');
 		$this->assertEquals('<input type="text" name="datetime" id="frm-datetime" class="form-control datetimepicker cool" placeholder="d.m.yyyy h:mm (31.12.1998 23:59)">', $dt->getControl()->render());
 	}
 
@@ -33,17 +33,17 @@ class DateTimeInputTest extends BaseTest
 		DateInput::$additionalHtmlClasses = ['date'];
 
 		$form = new BootstrapForm();
-		$dt = $form->addDateTime('datetime', 'Date and time');
+		$dt = $form->addBootstrapDateTime('datetime', 'Date and time');
 		$this->assertStringContainsString('class="form-control datetime"', $dt->getControl()->render());
 
-		$d = $form->addDate('date', 'Date');
+		$d = $form->addBootstrapDate('date', 'Date');
 		$this->assertStringContainsString('class="form-control date"', $d->getControl()->render());
 	}
 
 	public function testValidationWithValueFromDatabase(): void
 	{
 		$form = new BootstrapForm();
-		$dt = $form->addDateTime('datetime', 'Date and time');
+		$dt = $form->addBootstrapDateTime('datetime', 'Date and time');
 		$dt->setValue('2020-05-05 20:00:00');
 		$form->validate();
 		$this->assertEquals(new DateTime('2020-05-05 20:00:00'), $dt->getValue());
@@ -52,7 +52,7 @@ class DateTimeInputTest extends BaseTest
 	public function testValidationWithCorrectFormat(): void
 	{
 		$form = new BootstrapForm();
-		$dt = $form->addDateTime('datetime', 'Date and time');
+		$dt = $form->addBootstrapDateTime('datetime', 'Date and time');
 		$dt->setValue((new DateTime('2020-05-01'))->format($dt->format));
 		$form->validate();
 		$this->assertEquals(new DateTime('2020-05-01'), $dt->getValue());


### PR DESCRIPTION
renamed addDate, addDateTime to addBootstrapDate and addBootstrapDateTime. added Date/DateTime/Time/Color inputs which acts as default nette forms