### PR TITLE
nette/forms 3.2.9 — fixes NAME_SEPARATOR deprecation on PHP 8.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   ],
   "require": {
     "php": ">=8.1",
-    "nette/forms": "3.2.8",
+    "nette/forms": "3.2.9",
     "nette/application": "^3.0"
   },
   "require-dev": {

--- a/src/BootstrapRenderer.php
+++ b/src/BootstrapRenderer.php
@@ -328,7 +328,9 @@ class BootstrapRenderer implements FormRenderer
 	public function renderBegin(): string
 	{
 		foreach ($this->form->getControls() as $control) {
-			$control->setOption(RendererOptions::_RENDERED, false);
+			if ($control instanceof BaseControl || $control instanceof BootstrapRow) {
+				$control->setOption(RendererOptions::_RENDERED, false);
+			}
 		}
 
 		/** @var Html $el */
@@ -462,6 +464,10 @@ class BootstrapRenderer implements FormRenderer
 
 		// note that these are NOT form groups, these are groups specified to group
 		foreach ($parent->getControls() as $control) {
+			if (!$control instanceof BaseControl && !$control instanceof BootstrapRow) {
+				continue;
+			}
+
 			if ($control->getOption(RendererOptions::_RENDERED)) {
 				continue;
 			}

--- a/src/Inputs/DateInput.php
+++ b/src/Inputs/DateInput.php
@@ -5,6 +5,7 @@ namespace Contributte\FormsBootstrap\Inputs;
 use Contributte\FormsBootstrap\Enums\DateTimeFormat;
 use DateTime;
 use DateTimeInterface;
+use Nette\Forms\Control;
 use Nette\NotSupportedException;
 use Nette\Utils\Html;
 
@@ -54,7 +55,7 @@ class DateInput extends TextInput
 
 		parent::__construct($label, null);
 
-		$this->addRule(fn ($input) => DateTimeFormat::validate($this->format, $input->value), $this->invalidFormatMessage);
+		$this->addRule(fn (Control $input) => DateTimeFormat::validate($this->format, $input->getValue()), $this->invalidFormatMessage);
 
 		$this->setFormat(static::$defaultFormat);
 	}


### PR DESCRIPTION
nette/forms 3.2.9 replaces the deprecated IComponent::NAME_SEPARATOR constant (marked #[\Deprecated] in nette/component-model 3.2, emitting E_USER_DEPRECATED on every form render under PHP 8.4).

3.2.9 also ships stricter native/phpDoc types, so getControls() is now typed as iterable of Nette\Forms\Control — guard option access in BootstrapRenderer and type the DateInput validation rule accordingly.