### PR TITLE
ci: let the coverage workflow see CODECOV_TOKEN

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,5 +17,6 @@ jobs:
   coverage:
     name: "Nette Tester"
     uses: contributte/.github/.github/workflows/nette-tester-coverage-v2.yml@master
+    secrets: inherit
     with:
       php: "8.2"


### PR DESCRIPTION
The reusable nette-tester-coverage-v2 workflow reads secrets.CODECOV_TOKEN, but secrets do not propagate into a called workflow on their own — without secrets: inherit it resolves to empty. Every upload since the migration has died on "Token length: 0" / "Token required because branch is protected", and codecov-action does not fail the step, so the job stayed green while nothing landed.

Codecov has therefore been serving a snapshot from 2020-05-05 (47.94%, 23 files / 924 lines) against a src/ that now holds 34 files. It reports RadioInput, UploadInput, TextAreaInput, MultiselectInput and CheckboxListInput at 0% though all five have passing tests today.

contributte/console, application and webpack all pass secrets: inherit and report current numbers; forms-bootstrap, forms and event-dispatcher do not and are all stale. Match the working ones.