### PR TITLE
chore: upgrade PHPStan to 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,10 +24,10 @@
   "require-dev": {
     "contributte/qa": "^v0.3",
     "phpunit/phpunit": "^9.5",
-    "phpstan/phpstan": "^1.10",
-    "phpstan/phpstan-deprecation-rules": "^1.0",
-    "phpstan/phpstan-nette": "^1.0",
-    "phpstan/phpstan-strict-rules": "^1.0"
+    "phpstan/phpstan": "^2.2",
+    "phpstan/phpstan-deprecation-rules": "^2.0",
+    "phpstan/phpstan-nette": "^2.0",
+    "phpstan/phpstan-strict-rules": "^2.0"
   },
   "autoload": {
     "psr-4": {

--- a/src/BootstrapRenderer.php
+++ b/src/BootstrapRenderer.php
@@ -21,8 +21,8 @@ use Nette\Utils\Html;
  * @property int        $mode
  * @property string     $gridBreakPoint    Bootstrap grid breakpoint for side-by-side view. Default is 'sm'.
  *           NULL means not to use a breakpoint
- * @property-read array $config
- * @property-read array $configOverride
+ * @property-read mixed[] $config
+ * @property-read mixed[] $configOverride
  * @property bool       $groupHidden       if true, hidden fields will be grouped at the end. If false,
  *           hidden fields are placed where they were added. Default is true.
  */
@@ -94,7 +94,7 @@ class BootstrapRenderer implements FormRenderer
 			}
 		}
 
-		if ($el instanceof Html && $el !== null) {
+		if ($el instanceof Html) {
 			$origClass = null;
 			// go through all config and configure element accordingly
 			foreach ($config as $key => $value) {
@@ -646,9 +646,7 @@ class BootstrapRenderer implements FormRenderer
 	{
 		$description = $control->getOption(RendererOptions::DESCRIPTION);
 		if (is_string($description)) {
-			if ($control instanceof BaseControl) {
-				$description = $control->translate($description);
-			}
+			$description = $control->translate($description);
 		} elseif (!$description instanceof Html) {
 			$description = '';
 		}

--- a/src/Grid/BootstrapCell.php
+++ b/src/Grid/BootstrapCell.php
@@ -96,7 +96,7 @@ class BootstrapCell
 		$element = $renderer->configElem(RendererConfig::GRID_CELL, $element);
 		$element->class[] = $this->createClass();
 
-		foreach ($this->childControls as $childControl) { //@phpstan-ignore-line phpstan bug
+		foreach ($this->childControls as $childControl) {
 			$pairHtml = $renderer->renderPair($childControl);
 			$element->addHtml($pairHtml);
 		}

--- a/src/Traits/ChoiceInputTrait.php
+++ b/src/Traits/ChoiceInputTrait.php
@@ -5,9 +5,6 @@ namespace Contributte\FormsBootstrap\Traits;
 /**
  * Trait ChoiceInputTrait.
  * Provides basic functionality for inputs where one of more than one predefined values are possible.
- *
- * @property bool|array|null $disabled
- * @method int|string|array getValue()
  */
 trait ChoiceInputTrait
 {
@@ -35,8 +32,6 @@ trait ChoiceInputTrait
 		$disabled = $this->disabled;
 		if (is_array($disabled)) {
 			return isset($disabled[$value]) && $disabled[$value];
-		} elseif (!is_bool($disabled)) {
-			return $disabled === $value;
 		}
 
 		return false;

--- a/src/Traits/InputPromptTrait.php
+++ b/src/Traits/InputPromptTrait.php
@@ -3,7 +3,6 @@
 namespace Contributte\FormsBootstrap\Traits;
 
 use Nette\InvalidArgumentException;
-use Nette\NotSupportedException;
 
 /**
  * Trait InputPromptTrait.
@@ -21,15 +20,10 @@ trait InputPromptTrait
 			return $this;
 		}
 
-		if (!isset($this->items)) {
-			throw new NotSupportedException('This must be a ChoiceControl');
-		}
-
-		/** @var array<int, int|string|null> $keys */
 		$keys = array_keys($this->items);
-		if (in_array('', $keys, true) || in_array(null, $keys, true)) {
+		if (in_array('', $keys, true)) {
 			throw new InvalidArgumentException(
-				'There is an item whose value === "" or null .' .
+				'There is an item whose value === "" .' .
 				'Setting prompt would interfere with this value.'
 			);
 		}


### PR DESCRIPTION
Bumps `phpstan/phpstan` to `^2.2` and the deprecation-rules, nette and strict-rules extensions to `^2.0`.

| package | before | after |
| --- | --- | --- |
| `phpstan/phpstan` | `^1.10` (1.12.33) | `^2.2` (2.2.8) |
| `phpstan/phpstan-deprecation-rules` | `^1.0` (1.2.1) | `^2.0` (2.0.5) |
| `phpstan/phpstan-nette` | `^1.0` (1.3.8) | `^2.0` (2.0.12) |
| `phpstan/phpstan-strict-rules` | `^1.0` (1.6.2) | `^2.0` (2.0.12) |

PHPStan 2 reported 11 errors at level 7. Each is fixed at the cause rather than baselined — all of them turned out to be dead code or PHPDoc that contradicted Nette's own type declarations.

### `BootstrapRenderer`
- `$el instanceof Html && $el !== null` — the `!== null` half is unreachable after the `instanceof`.
- `renderDescription()` re-checked `$control instanceof BaseControl` on a parameter already typed `BaseControl`.
- `@property-read array $config` / `$configOverride` now carry the `mixed[]` value type that `getConfig()`/`getConfigOverride()` already declare.

### `BootstrapCell`
- Dropped a `//@phpstan-ignore-line phpstan bug` that no longer matches any reported error.

### `ChoiceInputTrait`
- Removed `@property bool|array|null $disabled` and `@method int|string|array getValue()`. Both contradicted Nette's real declarations (`BaseControl::$disabled` is `protected bool|array`, and `getValue()` is declared on `ChoiceControl`/`MultiChoiceControl`), so PHPStan 2 resolved the native types and flagged the tags.
- With the bogus `null` gone from `$disabled`, the `elseif (!is_bool($disabled)) { return $disabled === $value; }` branch is provably unreachable: since Nette 3.x, `ChoiceControl::setDisabled()` / `MultiChoiceControl::setDisabled()` store either a bool (delegated to `parent::setDisabled()`) or `array_fill_keys(...)`, never a bare scalar. The array case is still handled by the `is_array()` branch above it.

### `InputPromptTrait`
- `ChoiceControl::$items` is a non-nullable `array`, so the `isset($this->items)` guard and its `NotSupportedException` could never fire.
- `array_keys()` cannot produce a `null` key, so `in_array(null, $keys, true)` is always `false`; the check and the corresponding `@var` override are dropped. The exception message is updated to match what is actually tested (`""`).

## Verification

- `make phpstan` — no errors
- `make tests` — 48 passed, 59 assertions
- `make cs` — 54/54 clean (only the pre-existing PHPCS deprecation warnings from `contributte/qa`)

## Notes

- `composer.lock` is gitignored in this repo, so only the `composer.json` constraints change and CI resolves fresh.
- The strict-rules include in `phpstan.neon` is still commented out (`#we are not ready yet`). The package is bumped but stays disabled — enabling it is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)