### PR TITLE
tests: add end-to-end request/submission suite

### DIFF
--- a/tests/E2E/BaseE2ETest.php
+++ b/tests/E2E/BaseE2ETest.php
@@ -1,0 +1,92 @@
+<?php declare (strict_types = 1);
+
+namespace Tests\E2E;
+
+use Contributte\FormsBootstrap\BootstrapForm;
+use Nette\Application\Request as AppRequest;
+use Nette\Http;
+use Tests\BaseTest;
+
+/**
+ * Base for end-to-end tests: builds a real HTTP request, runs a real presenter
+ * through its whole lifecycle and lets the form receive the `submit` signal
+ * exactly the way it does in production.
+ */
+abstract class BaseE2ETest extends BaseTest
+{
+
+	/**
+	 * Signal that submits a form named `form` sitting directly on the presenter.
+	 */
+	protected const FORM_SIGNAL = 'form-submit';
+
+	protected TestPresenter $presenter;
+
+	/**
+	 * Submits $data to the form built by $formFactory and returns the form
+	 * after the request has been handled.
+	 *
+	 * @param callable(): BootstrapForm $formFactory
+	 * @param mixed[] $data payload of the request, without the signal field
+	 * @param array<string, Http\FileUpload> $files
+	 */
+	protected function submit(
+		callable $formFactory,
+		array $data,
+		array $files = [],
+		string $method = 'POST'
+	): BootstrapForm
+	{
+		$isPost = strcasecmp($method, 'POST') === 0;
+
+		// the `_do` hidden field the renderer emits for POST forms, `do` in the query for GET ones
+		$post = $isPost ? $data + ['_do' => self::FORM_SIGNAL] : [];
+		$query = $isPost ? [] : $data + ['do' => self::FORM_SIGNAL];
+
+		$httpRequest = new Http\Request(
+			new Http\UrlScript('http://localhost/index.php?' . http_build_query($query)),
+			post: $post,
+			files: $files,
+			// marks the request as same-site so Nette's CSRF check lets the signal through
+			cookies: [Http\Helpers::StrictCookieName => '1'],
+			headers: [],
+			method: $isPost ? 'POST' : 'GET',
+		);
+
+		$this->presenter = new TestPresenter();
+		$this->presenter->formFactory = $formFactory;
+		$this->presenter->injectPrimary($httpRequest, new Http\Response());
+		// canonicalization would need a router, and it is not what these tests are about
+		$this->presenter->autoCanonicalize = false;
+
+		$this->presenter->run(new AppRequest(
+			'Test',
+			$isPost ? 'POST' : 'GET',
+			['action' => 'default'] + $query,
+			$post,
+			$files,
+		));
+
+		/** @var BootstrapForm $form */
+		$form = $this->presenter->getComponent('form');
+
+		return $form;
+	}
+
+	/**
+	 * Renders a form to a string the same way a template would.
+	 */
+	protected function renderToString(BootstrapForm $form): string
+	{
+		ob_start();
+
+		try {
+			$form->render();
+
+			return (string) ob_get_contents();
+		} finally {
+			ob_end_clean();
+		}
+	}
+
+}

--- a/tests/E2E/BaseE2ETest.php
+++ b/tests/E2E/BaseE2ETest.php
@@ -5,6 +5,7 @@ namespace Tests\E2E;
 use Contributte\FormsBootstrap\BootstrapForm;
 use Nette\Application\Request as AppRequest;
 use Nette\Http;
+use ReflectionMethod;
 use Tests\BaseTest;
 
 /**
@@ -55,7 +56,7 @@ abstract class BaseE2ETest extends BaseTest
 
 		$this->presenter = new TestPresenter();
 		$this->presenter->formFactory = $formFactory;
-		$this->presenter->injectPrimary($httpRequest, new Http\Response());
+		$this->injectHttp($this->presenter, $httpRequest, new Http\Response());
 		// canonicalization would need a router, and it is not what these tests are about
 		$this->presenter->autoCanonicalize = false;
 
@@ -87,6 +88,30 @@ abstract class BaseE2ETest extends BaseTest
 		} finally {
 			ob_end_clean();
 		}
+	}
+
+	/**
+	 * Hands the presenter its HTTP request and response.
+	 *
+	 * Presenter::injectPrimary() takes every collaborator a presenter can have and
+	 * its parameter order differs across the nette/application versions this library
+	 * supports, so the arguments are matched up by name and everything we do not
+	 * need (DI container, presenter factory, router, session, user, template
+	 * factory) is left null.
+	 */
+	private function injectHttp(TestPresenter $presenter, Http\IRequest $request, Http\IResponse $response): void
+	{
+		$args = [];
+
+		foreach ((new ReflectionMethod($presenter, 'injectPrimary'))->getParameters() as $parameter) {
+			$args[] = match ($parameter->getName()) {
+				'httpRequest' => $request,
+				'httpResponse' => $response,
+				default => null,
+			};
+		}
+
+		$presenter->injectPrimary(...$args);
 	}
 
 }

--- a/tests/E2E/FormSubmissionTest.php
+++ b/tests/E2E/FormSubmissionTest.php
@@ -1,0 +1,312 @@
+<?php declare (strict_types = 1);
+
+namespace Tests\E2E;
+
+use Contributte\FormsBootstrap\BootstrapForm;
+use Nette\Http\FileUpload;
+
+/**
+ * Drives whole requests through a real presenter: a form is rendered, a browser
+ * posts it back and the resulting values, errors and events are checked.
+ */
+class FormSubmissionTest extends BaseE2ETest
+{
+
+	public function testValidSubmitIsSuccessfulAndYieldsValues(): void
+	{
+		$form = $this->submit(
+			fn (): BootstrapForm => $this->contactForm(),
+			['name' => 'Dalibor', 'email' => 'dalibor@example.com']
+		);
+
+		$this->assertTrue($form->isSuccess());
+		$this->assertSame([], $form->getErrors());
+		$this->assertSame(
+			['name' => 'Dalibor', 'email' => 'dalibor@example.com'],
+			(array) $form->getValues()
+		);
+	}
+
+	public function testOnSuccessHandlerReceivesSubmittedValues(): void
+	{
+		$this->submit(
+			fn (): BootstrapForm => $this->contactForm(),
+			['name' => 'Dalibor', 'email' => 'dalibor@example.com']
+		);
+
+		$this->assertSame(
+			['name' => 'Dalibor', 'email' => 'dalibor@example.com'],
+			$this->presenter->succeededWith
+		);
+		$this->assertFalse($this->presenter->errored);
+	}
+
+	public function testMissingRequiredValueFailsValidation(): void
+	{
+		$form = $this->submit(
+			fn (): BootstrapForm => $this->contactForm(),
+			['name' => '', 'email' => 'dalibor@example.com']
+		);
+
+		$this->assertTrue((bool) $form->isSubmitted());
+		$this->assertFalse($form->isSuccess());
+		$this->assertSame(['Name is required'], $form->getErrors());
+		$this->assertNull($this->presenter->succeededWith);
+		$this->assertTrue($this->presenter->errored);
+	}
+
+	/**
+	 * addEmail() wires up the Email rule on its own, so a malformed address is
+	 * rejected without the caller adding any rule.
+	 */
+	public function testAddEmailValidatesTheAddressByItself(): void
+	{
+		$form = $this->submit(
+			fn (): BootstrapForm => $this->contactForm(),
+			['name' => 'Dalibor', 'email' => 'not-an-email']
+		);
+
+		$this->assertFalse($form->isSuccess());
+		$this->assertCount(1, $form['email']->getErrors());
+	}
+
+	public function testFailingRuleReportsItsOwnMessage(): void
+	{
+		$form = $this->submit(
+			function (): BootstrapForm {
+				$form = new BootstrapForm();
+				$form->setAction('/');
+				$form->addText('nick', 'Nick')->addRule(BootstrapForm::MinLength, 'Nick is too short', 5);
+				$form->addSubmit('send');
+
+				return $form;
+			},
+			['nick' => 'abc']
+		);
+
+		$this->assertFalse($form->isSuccess());
+		$this->assertSame(['Nick is too short'], $form->getErrors());
+		$this->assertSame(['Nick is too short'], $form['nick']->getErrors());
+	}
+
+	public function testRequestWithoutSignalIsNotSubmitted(): void
+	{
+		$form = $this->submit(
+			fn (): BootstrapForm => $this->contactForm(),
+			// a plain page view: the fields happen to be in the query, but no signal was sent
+			['name' => 'Dalibor', 'email' => 'dalibor@example.com'],
+			[],
+			'GET'
+		);
+
+		$this->assertFalse((bool) $form->isSubmitted());
+		$this->assertFalse($form->isSuccess());
+	}
+
+	public function testGetFormRoundTripsThroughTheQueryString(): void
+	{
+		$form = $this->submit(
+			function (): BootstrapForm {
+				$form = $this->contactForm();
+				$form->setMethod('get');
+
+				return $form;
+			},
+			['name' => 'Dalibor', 'email' => 'dalibor@example.com'],
+			[],
+			'GET'
+		);
+
+		$this->assertTrue($form->isSuccess());
+		$this->assertSame(
+			['name' => 'Dalibor', 'email' => 'dalibor@example.com'],
+			(array) $form->getValues()
+		);
+	}
+
+	public function testValuesRoundTripThroughContainers(): void
+	{
+		$form = $this->submit(
+			function (): BootstrapForm {
+				$form = new BootstrapForm();
+				$form->setAction('/');
+				$address = $form->addContainer('address');
+				$address->addText('street')->setRequired('Street is required');
+				$address->addText('city');
+				$form->addSubmit('send');
+
+				return $form;
+			},
+			['address' => ['street' => 'Ilica', 'city' => 'Zagreb']]
+		);
+
+		$this->assertTrue($form->isSuccess());
+		$this->assertSame(
+			['address' => ['street' => 'Ilica', 'city' => 'Zagreb']],
+			$this->toArray($form->getValues())
+		);
+	}
+
+	public function testValuesRoundTripThroughGridCells(): void
+	{
+		$form = $this->submit(
+			function (): BootstrapForm {
+				$form = new BootstrapForm();
+				$form->setAction('/');
+				$row = $form->addRow();
+				$row->addCell(6)->addText('name');
+				$row->addCell(6)->addText('mail');
+				$form->addSubmit('send');
+
+				return $form;
+			},
+			['name' => 'Dalibor', 'mail' => 'dalibor@example.com']
+		);
+
+		$this->assertTrue($form->isSuccess());
+		// grid rows and cells are layout-only, so the values stay flat on the form
+		$this->assertSame(
+			['name' => 'Dalibor', 'mail' => 'dalibor@example.com'],
+			$this->toArray($form->getValues())
+		);
+	}
+
+	public function testSubmitButtonIsReportedAsTheSubmitter(): void
+	{
+		$form = $this->submit(
+			fn (): BootstrapForm => $this->contactForm(),
+			['name' => 'Dalibor', 'email' => 'dalibor@example.com', 'send' => 'Send']
+		);
+
+		$submitter = $form->isSubmitted();
+		$this->assertSame($form['send'], $submitter);
+	}
+
+	public function testUploadedFileArrivesAsFileUpload(): void
+	{
+		$tmp = (string) tempnam(sys_get_temp_dir(), 'formsbootstrap');
+		file_put_contents($tmp, 'hello');
+
+		try {
+			$form = $this->submit(
+				function (): BootstrapForm {
+					$form = new BootstrapForm();
+					$form->setAction('/');
+					$form->addUpload('avatar', 'Avatar')->setButtonCaption('Choose');
+					$form->addSubmit('send');
+
+					return $form;
+				},
+				[],
+				[
+					'avatar' => new FileUpload([
+						'name' => 'avatar.txt',
+						'size' => 5,
+						'tmp_name' => $tmp,
+						'error' => UPLOAD_ERR_OK,
+					]),
+				]
+			);
+
+			$this->assertTrue($form->isSuccess());
+
+			/** @var FileUpload $upload */
+			$upload = $form->getValues()->avatar;
+			$this->assertInstanceOf(FileUpload::class, $upload);
+			$this->assertTrue($upload->isOk());
+			$this->assertSame('avatar.txt', $upload->getUntrustedName());
+			$this->assertSame(5, $upload->getSize());
+		} finally {
+			@unlink($tmp);
+		}
+	}
+
+	/**
+	 * Values submitted for a control that was never offered must not be accepted.
+	 */
+	public function testSelectRejectsValueThatIsNotAmongItems(): void
+	{
+		$form = $this->submit(
+			fn (): BootstrapForm => $this->countryForm(),
+			['country' => 'xx']
+		);
+
+		$this->assertNull($form['country']->getValue());
+	}
+
+	public function testSelectAcceptsAnOfferedValue(): void
+	{
+		$form = $this->submit(
+			fn (): BootstrapForm => $this->countryForm(),
+			['country' => 'hr']
+		);
+
+		$this->assertTrue($form->isSuccess());
+		$this->assertSame('hr', $form['country']->getValue());
+	}
+
+	public function testDisabledChoiceValueIsRejected(): void
+	{
+		$form = $this->submit(
+			function (): BootstrapForm {
+				$form = $this->countryForm();
+				$form['country']->setDisabled(['cz']);
+
+				return $form;
+			},
+			['country' => 'cz']
+		);
+
+		// the item was rendered disabled, so a forged post of it must not stick
+		$this->assertNull($form['country']->getValue());
+	}
+
+	public function testCheckboxListCollectsEveryCheckedValue(): void
+	{
+		$form = $this->submit(
+			function (): BootstrapForm {
+				$form = new BootstrapForm();
+				$form->setAction('/');
+				$form->addCheckboxList('langs', 'Languages', ['php' => 'PHP', 'js' => 'JS', 'go' => 'Go']);
+				$form->addSubmit('send');
+
+				return $form;
+			},
+			['langs' => ['php', 'go']]
+		);
+
+		$this->assertTrue($form->isSuccess());
+		$this->assertSame(['php', 'go'], $form['langs']->getValue());
+	}
+
+	private function contactForm(): BootstrapForm
+	{
+		$form = new BootstrapForm();
+		$form->setAction('/');
+		$form->addText('name', 'Name')->setRequired('Name is required');
+		$form->addEmail('email', 'Email')->setRequired('Email is required');
+		$form->addSubmit('send', 'Send');
+
+		return $form;
+	}
+
+	private function countryForm(): BootstrapForm
+	{
+		$form = new BootstrapForm();
+		$form->setAction('/');
+		$form->addSelect('country', 'Country', ['hr' => 'Croatia', 'cz' => 'Czechia']);
+		$form->addSubmit('send');
+
+		return $form;
+	}
+
+	/**
+	 * @param object $values
+	 * @return mixed[]
+	 */
+	private function toArray($values): array
+	{
+		return json_decode((string) json_encode($values), true);
+	}
+
+}

--- a/tests/E2E/TestPresenter.php
+++ b/tests/E2E/TestPresenter.php
@@ -1,0 +1,46 @@
+<?php declare (strict_types = 1);
+
+namespace Tests\E2E;
+
+use Contributte\FormsBootstrap\BootstrapForm;
+use Nette\Application\UI\Presenter;
+
+/**
+ * A real presenter used to drive a full request lifecycle in end-to-end tests.
+ * The form under test is built by a factory supplied by the test, and rendering
+ * is cut short right after the signal has been processed so that no template
+ * factory is needed.
+ */
+class TestPresenter extends Presenter
+{
+
+	/** @var callable(): BootstrapForm */
+	public $formFactory;
+
+	/** @var mixed[]|null values captured by the form's onSuccess handler */
+	public ?array $succeededWith = null;
+
+	/** @var bool whether the form's onError handler ran */
+	public bool $errored = false;
+
+	public function renderDefault(): void
+	{
+		// the signal has already been dispatched by now; stop before the template layer
+		$this->terminate();
+	}
+
+	protected function createComponentForm(): BootstrapForm
+	{
+		$form = ($this->formFactory)();
+
+		$form->onSuccess[] = function (BootstrapForm $form): void {
+			$this->succeededWith = (array) $form->getValues();
+		};
+		$form->onError[] = function (): void {
+			$this->errored = true;
+		};
+
+		return $form;
+	}
+
+}

--- a/tests/E2E/ValidationStateTest.php
+++ b/tests/E2E/ValidationStateTest.php
@@ -1,0 +1,140 @@
+<?php declare (strict_types = 1);
+
+namespace Tests\E2E;
+
+use Contributte\FormsBootstrap\BootstrapForm;
+use Contributte\FormsBootstrap\Enums\BootstrapVersion;
+use Contributte\FormsBootstrap\Enums\RendererOptions;
+
+/**
+ * Submits a form that fails validation and then re-renders it, the way a
+ * presenter does when it falls through to the template after onError.
+ */
+class ValidationStateTest extends BaseE2ETest
+{
+
+	public function testInvalidControlIsMarkedAndCarriesItsMessage(): void
+	{
+		$html = $this->renderToString($this->submitLoginForm(['name' => '', 'age' => '30']));
+
+		$this->assertStringContainsString('is-invalid', $html);
+		$this->assertStringContainsString('<div class="invalid-feedback">Name is required<br></div>', $html);
+	}
+
+	/**
+	 * autoShowValidation is on by default, so a failed submit also paints the
+	 * controls that did pass.
+	 */
+	public function testPassingControlsTurnValidOnFailedSubmit(): void
+	{
+		$form = $this->submitLoginForm(['name' => '', 'age' => '30']);
+
+		$this->assertTrue($form->isShowValidation());
+
+		$html = $this->renderToString($form);
+		$this->assertStringContainsString('is-valid', $html);
+	}
+
+	public function testAutoShowValidationCanBeTurnedOff(): void
+	{
+		$form = $this->submitLoginForm(
+			['name' => '', 'age' => '30'],
+			fn (BootstrapForm $form) => $form->setAutoShowValidation(false)
+		);
+
+		$this->assertFalse($form->isShowValidation());
+
+		$html = $this->renderToString($form);
+		// the failing control is still flagged, the passing one is left alone
+		$this->assertStringContainsString('is-invalid', $html);
+		$this->assertStringNotContainsString('is-valid', $html);
+	}
+
+	public function testSuccessfulSubmitRendersNoValidationState(): void
+	{
+		$form = $this->submitLoginForm(['name' => 'Dalibor', 'age' => '30']);
+
+		$this->assertTrue($form->isSuccess());
+
+		$html = $this->renderToString($form);
+		$this->assertStringNotContainsString('is-invalid', $html);
+		$this->assertStringNotContainsString('is-valid', $html);
+	}
+
+	public function testValidFeedbackMessageIsRenderedWhenConfigured(): void
+	{
+		$form = $this->submitLoginForm(
+			['name' => '', 'age' => '30'],
+			function (BootstrapForm $form): void {
+				$form['age']->setOption(RendererOptions::FEEDBACK_VALID, 'Age looks good');
+			}
+		);
+
+		$html = $this->renderToString($form);
+		$this->assertStringContainsString('<div class="valid-feedback">Age looks good<br></div>', $html);
+	}
+
+	/**
+	 * UploadInput wraps its <input> in a <div>, so the state class has to land
+	 * on the input itself rather than on the wrapper.
+	 */
+	public function testUploadInputMarksTheInnerInput(): void
+	{
+		$form = $this->submit(
+			function (): BootstrapForm {
+				$form = new BootstrapForm();
+				$form->setAction('/');
+				$form->addUpload('avatar', 'Avatar')->setButtonCaption('Choose')
+					->setRequired('Avatar is required');
+				$form->addSubmit('send');
+
+				return $form;
+			},
+			[]
+		);
+
+		$this->assertFalse($form->isSuccess());
+
+		$html = $this->renderToString($form);
+		$this->assertStringContainsString('class="custom-file-input is-invalid"', $html);
+	}
+
+	public function testBootstrap5UsesTheSameStateClasses(): void
+	{
+		BootstrapForm::switchBootstrapVersion(BootstrapVersion::V5);
+
+		try {
+			$html = $this->renderToString($this->submitLoginForm(['name' => '', 'age' => '30']));
+
+			$this->assertStringContainsString('is-invalid', $html);
+			$this->assertStringContainsString('<div class="invalid-feedback">Name is required<br></div>', $html);
+		} finally {
+			BootstrapForm::switchBootstrapVersion(BootstrapVersion::V4);
+		}
+	}
+
+	/**
+	 * @param mixed[] $data
+	 * @param callable(BootstrapForm): mixed|null $configure
+	 */
+	private function submitLoginForm(array $data, ?callable $configure = null): BootstrapForm
+	{
+		return $this->submit(
+			function () use ($configure): BootstrapForm {
+				$form = new BootstrapForm();
+				$form->setAction('/');
+				$form->addText('name', 'Name')->setRequired('Name is required');
+				$form->addText('age', 'Age');
+				$form->addSubmit('send', 'Send');
+
+				if ($configure !== null) {
+					$configure($form);
+				}
+
+				return $form;
+			},
+			$data
+		);
+	}
+
+}


### PR DESCRIPTION
Adds real end-to-end tests: instead of poking the form object directly, these drive **whole requests through a real Nette presenter**. A real `Nette\Http\Request` carries the POST body and the `_do` signal, `Presenter::run()` dispatches the `submit` signal, and the form receives it exactly the way it does in production.

## The harness

- **`tests/E2E/TestPresenter.php`** — a real `Nette\Application\UI\Presenter` that builds the form under test from a factory and calls `terminate()` in `renderDefault()`, right after the signal has been processed. That keeps the whole signal path real while avoiding the template factory, router and link generator entirely.
- **`tests/E2E/BaseE2ETest.php`** — `submit($formFactory, $data, $files, $method)` builds the HTTP + application request pair and returns the handled form; `renderToString()` re-renders it the way a template would. The same-site cookie is set so Nette's CSRF check lets the signal through, and `autoCanonicalize` is off since canonicalization would need a router.

## What is covered end to end

**Submission** (`FormSubmissionTest`)
- valid submit → `isSuccess()`, `getValues()`, and the payload `onSuccess` actually receives
- failed validation → submitted but not successful, per-control errors, `onError` firing, custom rule messages
- a request carrying field values but **no signal** is correctly not treated as a submit
- GET forms round-tripping through the query string
- values surviving `addContainer()` nesting, and staying flat through grid rows/cells (which are layout-only)
- the submit button reported as the submitter
- uploads arriving as a real `Nette\Http\FileUpload`
- choice controls rejecting a forged value that was never offered, **including values disabled via `setDisabled([...])`** — the behaviour behind the `ChoiceInputTrait` cleanup in #122

**Validation re-render** (`ValidationStateTest`)
- `is-invalid` plus the message in `invalid-feedback` after a failed submit
- `autoShowValidation` (on by default) painting the passing controls `is-valid`, and leaving them alone when switched off
- the `FEEDBACK_VALID` option rendering `valid-feedback`
- `UploadInput` putting the state class on its inner `<input>` rather than on the wrapper `<div>`
- Bootstrap 5 producing the same state classes

## Coverage

| | before | after |
| --- | --- | --- |
| Lines | 83.14% (705/848) | **86.32%** (732/848) |
| Methods | 63.27% (93/147) | **67.35%** (99/147) |

Biggest movers: `UploadInput` 59% → 95% lines, `FakeControlTrait` 17% → 67%, `BootstrapContainerTrait` 64% → 74%, `BootstrapRenderer` 82% → 84%.

## Scope note

This is the end-to-end half of the work. The remaining unit-coverage gaps are **not** addressed here and are worth a follow-up:

- `BootstrapRenderer` methods are still 41.67% — only side-by-side mode is ever rendered; **vertical and inline render modes have no tests at all**
- `BootstrapContainerTrait` is at 52% methods — many `add*()` factories are still never called
- `ChoiceInputTrait` / `StandardValidationTrait` show 0 covered *methods* despite their lines being covered; that is a pcov trait-attribution artifact, but direct unit tests would still be worth having

## Verification

`make tests` 70 passed (109 assertions) · `make phpstan` no errors · `make cs` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)