### PR TITLE
tests: cover the render modes, grid and factory gaps

### DIFF
--- a/tests/BootstrapFormTest.php
+++ b/tests/BootstrapFormTest.php
@@ -3,6 +3,7 @@
 namespace Tests;
 
 use Contributte\FormsBootstrap\BootstrapForm;
+use Contributte\FormsBootstrap\BootstrapRenderer;
 use Contributte\FormsBootstrap\Enums\BootstrapVersion;
 use Contributte\FormsBootstrap\Enums\RenderMode;
 use Nette\Forms\Rendering\DefaultFormRenderer;
@@ -34,6 +35,41 @@ class BootstrapFormTest extends BaseTest
 
 		BootstrapForm::switchBootstrapVersion(BootstrapVersion::V4);
 		$this->assertEquals(BootstrapVersion::V4, BootstrapForm::getBootstrapVersion());
+	}
+
+	public function testShowValidationAccessors(): void
+	{
+		$form = new BootstrapForm();
+		$this->assertFalse($form->isShowValidation());
+
+		$form->setShowValidation(true);
+
+		$this->assertTrue($form->isShowValidation());
+	}
+
+	public function testAnUnknownBootstrapVersionFallsBackToV4(): void
+	{
+		BootstrapForm::switchBootstrapVersion(99);
+
+		$this->assertEquals(BootstrapVersion::V4, BootstrapForm::getBootstrapVersion());
+	}
+
+	public function testAjaxClassIsAddedAndRemoved(): void
+	{
+		$form = new BootstrapForm();
+
+		$form->setAjax(true);
+		$this->assertContains('ajax', $form->getElementPrototype()->class);
+
+		$form->setAjax(false);
+		$this->assertNotContains('ajax', $form->getElementPrototype()->class);
+	}
+
+	public function testGetRendererReturnsTheBootstrapRenderer(): void
+	{
+		$form = new BootstrapForm();
+
+		$this->assertInstanceOf(BootstrapRenderer::class, $form->getRenderer());
 	}
 
 }

--- a/tests/Grid/BootstrapRowTest.php
+++ b/tests/Grid/BootstrapRowTest.php
@@ -1,0 +1,143 @@
+<?php declare (strict_types = 1);
+
+namespace Tests\Grid;
+
+use Contributte\FormsBootstrap\BootstrapForm;
+use Contributte\FormsBootstrap\Grid\BootstrapCell;
+use Contributte\FormsBootstrap\Grid\BootstrapRow;
+use Nette\Application\UI\Presenter;
+use Nette\NotImplementedException;
+use Tests\BaseTest;
+
+/**
+ * The row/cell objects themselves, and the "fake control" surface that lets a
+ * row sit in the component tree without being a real form value.
+ */
+class BootstrapRowTest extends BaseTest
+{
+
+	private BootstrapForm $form;
+
+	private BootstrapRow $row;
+
+	public function testCellsAreCollected(): void
+	{
+		$this->assertSame([], $this->row->getCells());
+
+		$first = $this->row->addCell(6);
+		$second = $this->row->addCell(6);
+
+		$this->assertSame([$first, $second], $this->row->getCells());
+		$this->assertContainsOnlyInstancesOf(BootstrapCell::class, $this->row->getCells());
+	}
+
+	public function testCellRemembersHowManyColumnsItSpans(): void
+	{
+		$cell = $this->row->addCell(4);
+
+		$this->assertSame(4, $cell->getNumOfColumns());
+	}
+
+	public function testCellPrototypeCanBeDecorated(): void
+	{
+		$cell = $this->row->addCell(6);
+
+		$cell->getElementPrototype()->setAttribute('data-role', 'left');
+
+		$this->assertStringContainsString('data-role="left"', (string) $cell->render());
+	}
+
+	public function testRowPrototypeCanBeDecorated(): void
+	{
+		$this->row->getElementPrototype()->setAttribute('data-role', 'row');
+		$this->row->addCell(12)->addText('a');
+
+		$this->assertStringContainsString('data-role="row"', $this->renderForm());
+	}
+
+	public function testGridBreakPointAccessors(): void
+	{
+		$this->assertSame('sm', $this->row->getGridBreakPoint());
+
+		$this->row->setGridBreakPoint('md');
+
+		$this->assertSame('md', $this->row->getGridBreakPoint());
+	}
+
+	public function testBreakPointReachesTheRenderedColumnClass(): void
+	{
+		$this->row->setGridBreakPoint('lg');
+		$this->row->addCell(4)->addText('a');
+
+		$this->assertStringContainsString('col-lg-4', $this->renderForm());
+	}
+
+	public function testOwnedNamesListsWhatWasAddedThroughTheRow(): void
+	{
+		$this->assertSame([], $this->row->getOwnedNames());
+
+		$this->row->addCell(6)->addText('name');
+		$this->row->addCell(6)->addText('mail');
+
+		$this->assertSame(['name', 'mail'], $this->row->getOwnedNames());
+	}
+
+	public function testRowIsNotRealFormValue(): void
+	{
+		$this->assertSame([], $this->row->getErrors());
+		$this->assertNull($this->row->getValue());
+		$this->assertTrue($this->row->isDisabled());
+		$this->assertTrue($this->row->isOmitted());
+	}
+
+	public function testRowCannotBeGivenValue(): void
+	{
+		$this->expectException(NotImplementedException::class);
+
+		$this->row->setValue('anything');
+	}
+
+	public function testValidatingRowDoesNothing(): void
+	{
+		$this->row->addCell(12)->addText('a')->setRequired('required');
+
+		$this->row->validate();
+
+		$this->assertSame([], $this->row->getErrors());
+	}
+
+	public function testControlsAddedThroughCellStayReachableOnForm(): void
+	{
+		$this->row->addCell(12)->addText('name', 'Name');
+
+		$this->assertSame('name', $this->form['name']->getName());
+	}
+
+	protected function setUp(): void
+	{
+		$this->form = new BootstrapForm();
+		$this->row = $this->form->addRow();
+		$this->form->setParent($this->createMock(Presenter::class));
+		// A real (non-empty) action makes Nette inject the "_do" signal field,
+		// mirroring production where the form is attached to a routed presenter.
+		$this->form->setAction('/');
+	}
+
+	/**
+	 * A row can only be drawn as part of a form render — that is when the
+	 * renderer learns which form it is working for.
+	 */
+	private function renderForm(): string
+	{
+		ob_start();
+
+		try {
+			$this->form->render();
+
+			return (string) ob_get_contents();
+		} finally {
+			ob_end_clean();
+		}
+	}
+
+}

--- a/tests/Inputs/UploadInputTest.php
+++ b/tests/Inputs/UploadInputTest.php
@@ -27,4 +27,22 @@ class UploadInputTest extends BaseTest
 		BootstrapForm::switchBootstrapVersion(BootstrapVersion::V4);
 	}
 
+	public function testButtonCaptionAccessor(): void
+	{
+		$form = new BootstrapForm();
+		$upload = $form->addUpload('file', 'caption');
+
+		$upload->setButtonCaption('upload');
+
+		$this->assertSame('upload', $upload->getButtonCaption());
+	}
+
+	public function testMultiUploadRendersTheMultipleAttribute(): void
+	{
+		$form = new BootstrapForm();
+		$upload = $form->addMultiUpload('files', 'caption')->setButtonCaption('upload');
+
+		$this->assertStringContainsString('multiple', (string) $upload->getControl());
+	}
+
 }

--- a/tests/Rendering/GroupRenderingTest.php
+++ b/tests/Rendering/GroupRenderingTest.php
@@ -1,0 +1,147 @@
+<?php declare (strict_types = 1);
+
+namespace Tests\Rendering;
+
+use Contributte\FormsBootstrap\BootstrapForm;
+use Contributte\FormsBootstrap\Enums\RendererOptions;
+use Nette\Application\UI\Presenter;
+use Nette\Utils\Html;
+use Tests\BaseTest;
+
+/**
+ * Form groups: the renderer draws them before any loose controls and honours
+ * the label, id and container options set on them.
+ */
+class GroupRenderingTest extends BaseTest
+{
+
+	private BootstrapForm $form;
+
+	public function testGroupLabelIsRendered(): void
+	{
+		$group = $this->form->addGroup('Personal');
+		$group->add($this->form->addText('name', 'Name'));
+
+		$this->assertStringContainsString('Personal', $this->render());
+	}
+
+	/**
+	 * An Html label keeps its attributes, but the configured element name wins,
+	 * so it is always emitted as the <legend> of the group's fieldset.
+	 */
+	public function testHtmlGroupLabelIsRenamedToLegendButKeepsItsAttributes(): void
+	{
+		$group = $this->form->addGroup(null);
+		$group->setOption(RendererOptions::LABEL, Html::el('h3', ['class' => 'fancy'])->setText('Personal'));
+		$group->add($this->form->addText('name', 'Name'));
+
+		$html = $this->render();
+
+		$this->assertStringContainsString('<legend class="fancy">Personal</legend>', $html);
+		$this->assertStringNotContainsString('<h3', $html);
+	}
+
+	public function testGroupIdEndsUpOnTheContainer(): void
+	{
+		$group = $this->form->addGroup('Personal');
+		$group->setOption(RendererOptions::ID, 'personal-group');
+		$group->add($this->form->addText('name', 'Name'));
+
+		$this->assertStringContainsString('id="personal-group"', $this->render());
+	}
+
+	/**
+	 * Same for the container: naming a different tag does not change it, the
+	 * group is always drawn as a fieldset.
+	 */
+	public function testStringGroupContainerIsStillRenderedAsFieldset(): void
+	{
+		$group = $this->form->addGroup('Personal');
+		$group->setOption(RendererOptions::CONTAINER, 'section');
+		$group->add($this->form->addText('name', 'Name'));
+
+		$html = $this->render();
+
+		$this->assertStringContainsString('<fieldset>', $html);
+		$this->assertStringNotContainsString('<section', $html);
+	}
+
+	public function testGroupContainerCanBeAnHtmlElement(): void
+	{
+		$group = $this->form->addGroup('Personal');
+		$group->setOption(RendererOptions::CONTAINER, Html::el('section', ['class' => 'panel']));
+		$group->add($this->form->addText('name', 'Name'));
+
+		$this->assertStringContainsString('class="panel"', $this->render());
+	}
+
+	public function testNonVisualGroupIsSkipped(): void
+	{
+		$group = $this->form->addGroup('Hidden away');
+		$group->setOption(RendererOptions::VISUAL, false);
+		$group->add($this->form->addText('name', 'Name'));
+
+		$html = $this->render();
+
+		$this->assertStringNotContainsString('Hidden away', $html);
+		// its controls are still drawn, just not inside a group container
+		$this->assertStringContainsString('name="name"', $html);
+	}
+
+	public function testAnEmptyGroupIsSkipped(): void
+	{
+		$this->form->addGroup('Nothing here');
+		// addGroup() makes the new group current, so step out of it before
+		// adding a control that should stay loose
+		$this->form->setCurrentGroup(null);
+		$this->form->addText('name', 'Name');
+
+		$html = $this->render();
+
+		$this->assertStringNotContainsString('Nothing here', $html);
+		$this->assertStringContainsString('name="name"', $html);
+	}
+
+	/**
+	 * Groups are walked first so their controls get marked as rendered, but the
+	 * markup is assembled the other way round: ungrouped controls are emitted
+	 * first and the groups follow, whatever order they were added in.
+	 */
+	public function testUngroupedControlsAreRenderedBeforeGroups(): void
+	{
+		$group = $this->form->addGroup('Personal');
+		$group->add($this->form->addText('grouped', 'Grouped'));
+		$this->form->setCurrentGroup(null);
+		$this->form->addText('loose', 'Loose');
+
+		$html = $this->render();
+
+		$this->assertLessThan(
+			strpos($html, 'name="grouped"'),
+			strpos($html, 'name="loose"')
+		);
+	}
+
+	protected function setUp(): void
+	{
+		$this->form = new BootstrapForm();
+		$this->form->setParent($this->createMock(Presenter::class));
+		// A real (non-empty) action makes Nette inject the "_do" signal field,
+		// mirroring production where the form is attached to a routed presenter.
+		$this->form->setAction('/');
+	}
+
+	private function render(): string
+	{
+		ob_start();
+
+		try {
+			$this->form->render();
+
+			return (string) ob_get_contents();
+		} finally {
+			ob_end_clean();
+		}
+	}
+
+}

--- a/tests/Rendering/RendererConfigTest.php
+++ b/tests/Rendering/RendererConfigTest.php
@@ -1,0 +1,211 @@
+<?php declare (strict_types = 1);
+
+namespace Tests\Rendering;
+
+use Contributte\FormsBootstrap\BootstrapForm;
+use Contributte\FormsBootstrap\BootstrapRenderer;
+use Contributte\FormsBootstrap\Enums\RendererConfig as Cnf;
+use Contributte\FormsBootstrap\Enums\RenderMode;
+use Nette\Application\UI\Presenter;
+use Nette\InvalidArgumentException;
+use Nette\Utils\Html;
+use Tests\BaseTest;
+
+/**
+ * Exercises configElem() — the one function every drawn element goes through —
+ * and the renderer's own accessors.
+ */
+class RendererConfigTest extends BaseTest
+{
+
+	private BootstrapRenderer $renderer;
+
+	public function testClassSetReplacesExistingClasses(): void
+	{
+		$el = Html::el('div', ['class' => 'original']);
+
+		$this->renderer->configElem([Cnf::CLASS_SET => ['brand-new']], $el);
+
+		$this->assertSame('<div class="brand-new"></div>', (string) $el);
+	}
+
+	public function testClassAddKeepsExistingClasses(): void
+	{
+		$el = Html::el('div', ['class' => 'original']);
+
+		$this->renderer->configElem([Cnf::CLASS_ADD => ['extra']], $el);
+
+		$this->assertSame('<div class="original extra"></div>', (string) $el);
+	}
+
+	public function testClassRemoveDropsOnlyTheNamedClass(): void
+	{
+		$el = Html::el('div', ['class' => 'keep drop']);
+
+		$this->renderer->configElem([Cnf::CLASS_REMOVE => ['drop']], $el);
+
+		$this->assertSame('<div class="keep"></div>', (string) $el);
+	}
+
+	public function testAttributesAreApplied(): void
+	{
+		$el = Html::el('input');
+
+		$this->renderer->configElem([Cnf::ATTRIBUTES => ['placeholder' => 'Type here']], $el);
+
+		$this->assertSame('<input placeholder="Type here">', (string) $el);
+	}
+
+	public function testElementNameChangesTheTag(): void
+	{
+		$el = Html::el('div');
+
+		$configured = $this->renderer->configElem([Cnf::ELEMENT_NAME => 'span'], $el);
+
+		$this->assertNotNull($configured);
+		$this->assertSame('<span></span>', (string) $configured);
+	}
+
+	public function testContainerWrapsTheElement(): void
+	{
+		$el = Html::el('input');
+
+		$configured = $this->renderer->configElem([
+			Cnf::CONTAINER => [
+				Cnf::ELEMENT_NAME => 'div',
+				Cnf::CLASS_SET => ['wrapper'],
+			],
+		], $el);
+
+		$this->assertNotNull($configured);
+		$this->assertSame('<div class="wrapper"><input></div>', (string) $configured);
+	}
+
+	public function testNullElementWithoutContainerStaysNull(): void
+	{
+		$this->assertNull($this->renderer->configElem([Cnf::CLASS_ADD => ['nothing-to-add-to']], null));
+	}
+
+	public function testStringConfigIsLookedUpInTheConfig(): void
+	{
+		$el = $this->renderer->configElem(Cnf::INPUT_INVALID, Html::el('input'));
+
+		$this->assertNotNull($el);
+		$this->assertStringContainsString('is-invalid', (string) $el);
+	}
+
+	public function testGridBreakPointAccessors(): void
+	{
+		$this->assertSame('sm', $this->renderer->getGridBreakPoint());
+
+		$this->renderer->setGridBreakPoint('lg');
+
+		$this->assertSame('lg', $this->renderer->getGridBreakPoint());
+	}
+
+	public function testBreakPointEndsUpInSideBySideColumnClasses(): void
+	{
+		$form = $this->sideBySideForm();
+		$form->getRenderer()->setGridBreakPoint('lg');
+		$form->addText('a', 'b');
+
+		$this->assertStringContainsString('col-lg-3', $this->render($form));
+	}
+
+	public function testColumnsCanBeChanged(): void
+	{
+		$form = $this->sideBySideForm();
+		$form->getRenderer()->setColumns(4);
+		$form->addText('a', 'b');
+
+		$html = $this->render($form);
+
+		$this->assertStringContainsString('col-sm-4', $html);
+		// the control takes whatever is left of the twelve
+		$this->assertStringContainsString('col-sm-8', $html);
+	}
+
+	public function testColumnsCanBeSetExplicitly(): void
+	{
+		$form = $this->sideBySideForm();
+		$form->getRenderer()->setColumns(2, 6);
+		$form->addText('a', 'b');
+
+		$html = $this->render($form);
+
+		$this->assertStringContainsString('col-sm-2', $html);
+		$this->assertStringContainsString('col-sm-6', $html);
+	}
+
+	public function testGroupHiddenAccessors(): void
+	{
+		$this->assertTrue($this->renderer->isGroupHidden());
+
+		$this->renderer->setGroupHidden(false);
+
+		$this->assertFalse($this->renderer->isGroupHidden());
+	}
+
+	public function testHiddenFieldsStayInPlaceWhenGroupingIsOff(): void
+	{
+		$form = new BootstrapForm();
+		$form->setParent($this->createMock(Presenter::class));
+		$form->setAction('/');
+		$form->getRenderer()->setGroupHidden(false);
+		$form->addHidden('secret', 'v');
+		$form->addText('a', 'b');
+
+		$html = $this->render($form);
+
+		// the hidden input keeps its position instead of being moved to the end
+		$this->assertLessThan(
+			strpos($html, 'name="a"'),
+			strpos($html, 'name="secret"')
+		);
+	}
+
+	public function testModeAccessor(): void
+	{
+		$this->assertSame(RenderMode::VERTICAL_MODE, (new BootstrapRenderer())->getMode());
+		$this->assertSame(
+			RenderMode::SIDE_BY_SIDE_MODE,
+			(new BootstrapRenderer(RenderMode::SIDE_BY_SIDE_MODE))->getMode()
+		);
+	}
+
+	public function testRenderControlsRejectsNonContainer(): void
+	{
+		$this->expectException(InvalidArgumentException::class);
+
+		$this->renderer->renderControls(Html::el('div'));
+	}
+
+	protected function setUp(): void
+	{
+		$this->renderer = new BootstrapRenderer();
+	}
+
+	private function sideBySideForm(): BootstrapForm
+	{
+		$form = new BootstrapForm();
+		$form->setRenderer(new BootstrapRenderer(RenderMode::SIDE_BY_SIDE_MODE));
+		$form->setParent($this->createMock(Presenter::class));
+		$form->setAction('/');
+
+		return $form;
+	}
+
+	private function render(BootstrapForm $form): string
+	{
+		ob_start();
+
+		try {
+			$form->render();
+
+			return (string) ob_get_contents();
+		} finally {
+			ob_end_clean();
+		}
+	}
+
+}

--- a/tests/Rendering/VerticalTest.php
+++ b/tests/Rendering/VerticalTest.php
@@ -1,0 +1,122 @@
+<?php declare (strict_types = 1);
+
+namespace Tests\Rendering;
+
+use Contributte\FormsBootstrap\BootstrapForm;
+use Contributte\FormsBootstrap\BootstrapRenderer;
+use Contributte\FormsBootstrap\Enums\RenderMode;
+use Nette\Application\UI\Presenter;
+use Tests\BaseTest;
+
+/**
+ * Snapshot tests for the vertical render mode, the renderer's default.
+ * Side-by-side is covered by SideBySideTest.
+ */
+class VerticalTest extends BaseTest
+{
+
+	/** @var BootstrapForm */
+	private $form;
+
+	/**
+	 * @return array<string, array{string, callable(BootstrapForm): void}>
+	 */
+	public static function provideForms(): array
+	{
+		return [
+			'text' => [
+				'vertical/text.html',
+				function (BootstrapForm $form): void {
+					$form->addText('a', 'b');
+				}],
+			'text with description' => [
+			'vertical/text_description.html',
+			function (BootstrapForm $form): void {
+				$form->addText('a', 'b')->setOption('description', 'Helpful hint');
+			}],
+			'checkbox' => [
+			'vertical/checkbox.html',
+			function (BootstrapForm $form): void {
+				$form->addCheckbox('a', 'b');
+			}],
+			'checkbox list' => [
+			'vertical/checkbox_list.html',
+			function (BootstrapForm $form): void {
+				$form->addCheckboxList('a', 'b', ['x' => 'X', 'y' => 'Y']);
+			}],
+			'radio list' => [
+			'vertical/radio_list.html',
+			function (BootstrapForm $form): void {
+				$form->addRadioList('a', 'b', ['x' => 'X', 'y' => 'Y']);
+			}],
+			'select' => [
+			'vertical/select.html',
+			function (BootstrapForm $form): void {
+				$form->addSelect('a', 'b', ['x' => 'X', 'y' => 'Y']);
+			}],
+			'textarea' => [
+			'vertical/textarea.html',
+			function (BootstrapForm $form): void {
+				$form->addTextArea('a', 'b');
+			}],
+			'submit' => [
+			'vertical/submit.html',
+			function (BootstrapForm $form): void {
+				$form->addSubmit('a', 'b');
+			}],
+			'error' => [
+			'vertical/text_error.html',
+			function (BootstrapForm $form): void {
+				$form->addText('a')->addError('test-error');
+			}],
+			'form own error' => [
+			'vertical/form_error.html',
+			function (BootstrapForm $form): void {
+				$form->addText('a', 'b');
+				$form->addError('whole form is wrong');
+			}],
+			'grid row' => [
+			'vertical/grid.html',
+			function (BootstrapForm $form): void {
+				$row = $form->addRow();
+				$row->addCell(6)->addText('name', 'Name');
+				$row->addCell(6)->addText('mail', 'Mail');
+			}],
+			'hidden field is grouped last' => [
+			'vertical/hidden.html',
+			function (BootstrapForm $form): void {
+				$form->addHidden('secret', 'v');
+				$form->addText('a', 'b');
+			}],
+		];
+	}
+
+	/**
+	 * @dataProvider provideForms
+	 * @param callable(BootstrapForm): void $build
+	 */
+	public function testRendering(string $fixture, callable $build): void
+	{
+		$build($this->form);
+		$this->expectOutputString($this->loadTextData($fixture));
+		$this->form->render();
+	}
+
+	public function testVerticalIsTheDefaultMode(): void
+	{
+		$form = new BootstrapForm();
+
+		$this->assertSame(RenderMode::VERTICAL_MODE, $form->getRenderMode());
+	}
+
+	protected function setUp(): void
+	{
+		$this->form = new BootstrapForm();
+		$this->form->setRenderer(new BootstrapRenderer(RenderMode::VERTICAL_MODE));
+		$this->form->setParent($this->createMock(Presenter::class));
+		// A real (non-empty) action makes Nette inject the "_do" signal field,
+		// mirroring production where the form is attached to a routed presenter.
+		$this->form->setAction('/');
+	}
+
+}

--- a/tests/Traits/BootstrapContainerTraitTest.php
+++ b/tests/Traits/BootstrapContainerTraitTest.php
@@ -1,0 +1,136 @@
+<?php declare (strict_types = 1);
+
+namespace Tests\Traits;
+
+use Contributte\FormsBootstrap\BootstrapForm;
+use Contributte\FormsBootstrap\Inputs\DateTimeControl;
+use Contributte\FormsBootstrap\Inputs\TextInput;
+use Contributte\FormsBootstrap\Inputs\UploadInput;
+use Tests\BaseTest;
+
+/**
+ * The add*() factories that BootstrapForm and BootstrapContainer share.
+ */
+class BootstrapContainerTraitTest extends BaseTest
+{
+
+	public function testAddDateTimeProducesDateTimeLocalInput(): void
+	{
+		$form = new BootstrapForm();
+		$input = $form->addDateTime('when', 'When');
+
+		$this->assertInstanceOf(DateTimeControl::class, $input);
+		$this->assertStringContainsString('type="datetime-local"', (string) $input->getControl());
+	}
+
+	public function testAddTimeProducesTimeInput(): void
+	{
+		$form = new BootstrapForm();
+		$input = $form->addTime('when', 'When');
+
+		$this->assertInstanceOf(DateTimeControl::class, $input);
+		$this->assertStringContainsString('type="time"', (string) $input->getControl());
+	}
+
+	public function testAddIntegerAcceptsWholeNumbersOnly(): void
+	{
+		$form = new BootstrapForm();
+		$input = $form->addInteger('count', 'Count');
+
+		$this->assertInstanceOf(TextInput::class, $input);
+		$this->assertStringContainsString('type="number"', (string) $input->getControl());
+
+		// the Integer rule casts the raw string once the control is validated
+		$input->setValue('12');
+		$input->validate();
+		$this->assertSame(12, $input->getValue());
+		$this->assertSame([], $input->getErrors());
+	}
+
+	public function testAddIntegerRejectsNonWholeNumber(): void
+	{
+		$form = new BootstrapForm();
+		$input = $form->addInteger('count', 'Count');
+
+		$input->setValue('abc');
+		$input->validate();
+
+		$this->assertCount(1, $input->getErrors());
+	}
+
+	public function testAddFloatAcceptsDecimals(): void
+	{
+		$form = new BootstrapForm();
+		$input = $form->addFloat('ratio', 'Ratio');
+
+		$this->assertInstanceOf(TextInput::class, $input);
+		$this->assertStringContainsString('step="any"', (string) $input->getControl());
+
+		$input->setValue('1.5');
+		$input->validate();
+		$this->assertSame(1.5, $input->getValue());
+	}
+
+	public function testAddPasswordHidesWhatIsTyped(): void
+	{
+		$form = new BootstrapForm();
+		$input = $form->addPassword('secret', 'Secret');
+
+		$this->assertStringContainsString('type="password"', (string) $input->getControl());
+		$this->assertStringContainsString('form-control', (string) $input->getControl());
+	}
+
+	public function testAddMultiUploadTakesSeveralFiles(): void
+	{
+		$form = new BootstrapForm();
+		$input = $form->addMultiUpload('files', 'Files');
+
+		$this->assertInstanceOf(UploadInput::class, $input);
+
+		$input->setButtonCaption('Pick');
+		$html = (string) $input->getControl();
+		$this->assertStringContainsString('multiple', $html);
+		$this->assertStringContainsString('type="file"', $html);
+	}
+
+	public function testAddInputErrorAttachesTheErrorToTheNamedControl(): void
+	{
+		$form = new BootstrapForm();
+		$form->addText('name', 'Name');
+
+		$form->addInputError('name', 'that name is taken');
+
+		$this->assertSame(['that name is taken'], $form['name']->getErrors());
+		$this->assertTrue($form->hasErrors());
+	}
+
+	public function testAddColorProducesColorInput(): void
+	{
+		$form = new BootstrapForm();
+		$input = $form->addColor('shade', 'Shade');
+
+		$this->assertStringContainsString('type="color"', (string) $input->getControl());
+	}
+
+	public function testAddButtonIsNotSubmitter(): void
+	{
+		$form = new BootstrapForm();
+		$button = $form->addButton('go', 'Go');
+
+		$html = (string) $button->getControl();
+		$this->assertStringContainsString('btn', $html);
+		$this->assertStringNotContainsString('type="submit"', $html);
+	}
+
+	public function testFactoriesAlsoWorkInsideContainer(): void
+	{
+		$form = new BootstrapForm();
+		$container = $form->addContainer('nested');
+		$container->addPassword('secret', 'Secret');
+		$container->addInteger('count', 'Count');
+
+		$this->assertStringContainsString('type="password"', (string) $container['secret']->getControl());
+		$this->assertStringContainsString('name="nested[count]"', (string) $container['count']->getControl());
+	}
+
+}

--- a/tests/Traits/ChoiceInputTraitTest.php
+++ b/tests/Traits/ChoiceInputTraitTest.php
@@ -1,0 +1,164 @@
+<?php declare (strict_types = 1);
+
+namespace Tests\Traits;
+
+use Contributte\FormsBootstrap\BootstrapForm;
+use Nette\Utils\Html;
+use Tests\BaseTest;
+
+/**
+ * The disabled/selected logic shared by radio, checkbox-list and select,
+ * observed through the HTML those controls render.
+ */
+class ChoiceInputTraitTest extends BaseTest
+{
+
+	/**
+	 * Known gap: RadioInput::getControl() only ever asks isValueDisabled() per
+	 * item and never calls isControlDisabled(), so a radio list disabled as a
+	 * whole still renders as interactive. CheckboxListInput and SelectInput both
+	 * put the attribute on their element. Pinned here so that fixing RadioInput
+	 * shows up as a failure of this test rather than going unnoticed.
+	 */
+	public function testDisablingTheWholeRadioListIsNotReflectedInTheHtml(): void
+	{
+		$form = new BootstrapForm();
+		$radio = $form->addRadioList('a', 'b', ['x' => 'X', 'y' => 'Y']);
+		$radio->setDisabled(true);
+
+		$this->assertStringNotContainsString('disabled', (string) $radio->getControl());
+	}
+
+	public function testDisablingRadioListClearsWhateverWasSelected(): void
+	{
+		$form = new BootstrapForm();
+		$radio = $form->addRadioList('a', 'b', ['x' => 'X', 'y' => 'Y']);
+		$radio->setValue('x');
+
+		$radio->setDisabled(true);
+
+		$this->assertNull($radio->getValue());
+	}
+
+	public function testValueDisabledOneByOneIsNotReturned(): void
+	{
+		$form = new BootstrapForm();
+		$radio = $form->addRadioList('a', 'b', ['x' => 'X', 'y' => 'Y']);
+		$radio->setValue('x');
+
+		$radio->setDisabled(['x']);
+
+		$this->assertNull($radio->getValue());
+	}
+
+	public function testDisablingSingleValueLeavesOthersAlone(): void
+	{
+		$form = new BootstrapForm();
+		$radio = $form->addRadioList('a', 'b', ['x' => 'X', 'y' => 'Y']);
+		$radio->setDisabled(['x']);
+
+		$html = (string) $radio->getControl();
+
+		$this->assertSame(1, substr_count($html, 'disabled'));
+		// the disabled one is x, so the input carrying value="x" is the disabled one
+		$this->assertMatchesRegularExpression('#<input[^>]*value="x"[^>]*disabled#', $html);
+	}
+
+	public function testSelectedRadioValueIsChecked(): void
+	{
+		$form = new BootstrapForm();
+		$radio = $form->addRadioList('a', 'b', ['x' => 'X', 'y' => 'Y']);
+		$radio->setDefaultValue('y');
+
+		$html = (string) $radio->getControl();
+
+		$this->assertMatchesRegularExpression('#<input[^>]*value="y"[^>]*checked#', $html);
+		$this->assertDoesNotMatchRegularExpression('#<input[^>]*value="x"[^>]*checked#', $html);
+	}
+
+	public function testNothingIsCheckedWithoutDefaultValue(): void
+	{
+		$form = new BootstrapForm();
+		$radio = $form->addRadioList('a', 'b', ['x' => 'X', 'y' => 'Y']);
+
+		$this->assertStringNotContainsString('checked', (string) $radio->getControl());
+	}
+
+	public function testWholeSelectIsDisabled(): void
+	{
+		$form = new BootstrapForm();
+		$select = $form->addSelect('a', 'b', ['x' => 'X']);
+		$select->setDisabled(true);
+
+		$this->assertStringContainsString('disabled', (string) $select->getControl());
+	}
+
+	public function testWholeCheckboxListIsDisabledThroughItsFieldset(): void
+	{
+		$form = new BootstrapForm();
+		$list = $form->addCheckboxList('a', 'b', ['x' => 'X', 'y' => 'Y']);
+		$list->setDisabled(true);
+
+		$html = (string) $list->getControl();
+
+		// one attribute on the fieldset disables every checkbox inside it
+		$this->assertStringStartsWith('<fieldset disabled>', $html);
+		$this->assertSame(1, substr_count($html, 'disabled'));
+	}
+
+	public function testWholeMultiselectIsDisabled(): void
+	{
+		$form = new BootstrapForm();
+		$multi = $form->addMultiSelect('a', 'b', ['x' => 'X']);
+		$multi->setDisabled(true);
+
+		$this->assertStringContainsString('disabled', (string) $multi->getControl());
+	}
+
+	public function testRadioListShowsInvalidStateOnEveryOption(): void
+	{
+		$form = new BootstrapForm();
+		$radio = $form->addRadioList('a', 'b', ['x' => 'X', 'y' => 'Y']);
+		$radio->addError('nope');
+
+		$html = (string) $radio->showValidation($radio->getControl());
+
+		$this->assertSame(2, substr_count($html, 'is-invalid'));
+	}
+
+	public function testCheckboxListShowsInvalidStateOnEveryOption(): void
+	{
+		$form = new BootstrapForm();
+		$list = $form->addCheckboxList('a', 'b', ['x' => 'X', 'y' => 'Y']);
+		$list->addError('nope');
+
+		$html = (string) $list->showValidation($list->getControl());
+
+		$this->assertSame(2, substr_count($html, 'is-invalid'));
+	}
+
+	public function testCheckboxListShowsValidStateWhenThereAreNoErrors(): void
+	{
+		$form = new BootstrapForm();
+		$list = $form->addCheckboxList('a', 'b', ['x' => 'X']);
+
+		$html = (string) $list->showValidation($list->getControl());
+
+		$this->assertStringContainsString('is-valid', $html);
+		$this->assertStringNotContainsString('is-invalid', $html);
+	}
+
+	public function testCheckboxShowsInvalidStateOnItsInput(): void
+	{
+		$form = new BootstrapForm();
+		$checkbox = $form->addCheckbox('a', 'b');
+		$checkbox->addError('nope');
+
+		/** @var Html $control */
+		$control = $checkbox->getControl();
+		$html = (string) $checkbox->showValidation($control);
+
+		$this->assertStringContainsString('is-invalid', $html);
+	}
+
+}

--- a/tests/data/vertical/checkbox.html
+++ b/tests/data/vertical/checkbox.html
@@ -1,0 +1,7 @@
+<form action="/" method="post" id="frm-">
+<div class="form-group">
+	
+
+	<label class="custom-control custom-checkbox"><input type="checkbox" class="custom-control-input" name="a" id="frm--a" data-nette-rules="[]"><label class="custom-control-label" for="frm--a">b</label></label>
+</div>
+<input type="hidden" name="_do" value="-submit"></form>

--- a/tests/data/vertical/checkbox_list.html
+++ b/tests/data/vertical/checkbox_list.html
@@ -1,0 +1,7 @@
+<form action="/" method="post" id="frm-">
+<div class="form-group">
+	<label>b</label>
+
+	<fieldset><label class="custom-control custom-checkbox"><input type="checkbox" class="custom-control-input" name="a[]" id="frm--a0" data-nette-rules="[]" value="x"><label class="custom-control-label" for="frm--a0">X</label></label><label class="custom-control custom-checkbox"><input type="checkbox" class="custom-control-input" name="a[]" id="frm--a1" data-nette-rules="[]" value="y"><label class="custom-control-label" for="frm--a1">Y</label></label></fieldset>
+</div>
+<input type="hidden" name="_do" value="-submit"></form>

--- a/tests/data/vertical/form_error.html
+++ b/tests/data/vertical/form_error.html
@@ -1,0 +1,7 @@
+<form action="/" method="post" id="frm-"><div class="alert alert-danger">whole form is wrong</div>
+<div class="form-group">
+	<label for="frm--a">b</label>
+
+	<input type="text" name="a" id="frm--a" class="form-control">
+</div>
+<input type="hidden" name="_do" value="-submit"></form>

--- a/tests/data/vertical/grid.html
+++ b/tests/data/vertical/grid.html
@@ -1,0 +1,13 @@
+<form action="/" method="post" id="frm-"><div class="form-row"><div class="col-sm-6">
+<div class="form-group">
+	<label for="frm--name">Name</label>
+
+	<input type="text" name="name" id="frm--name" class="form-control">
+</div>
+</div><div class="col-sm-6">
+<div class="form-group">
+	<label for="frm--mail">Mail</label>
+
+	<input type="text" name="mail" id="frm--mail" class="form-control">
+</div>
+</div></div><input type="hidden" name="_do" value="-submit"></form>

--- a/tests/data/vertical/hidden.html
+++ b/tests/data/vertical/hidden.html
@@ -1,0 +1,7 @@
+<form action="/" method="post" id="frm-">
+<div class="form-group">
+	<label for="frm--a">b</label>
+
+	<input type="text" name="a" id="frm--a" class="form-control">
+</div>
+<input type="hidden" name="secret" value="v"><input type="hidden" name="_do" value="-submit"></form>

--- a/tests/data/vertical/radio_list.html
+++ b/tests/data/vertical/radio_list.html
@@ -1,0 +1,7 @@
+<form action="/" method="post" id="frm-">
+<div class="form-group">
+	<label>b</label>
+
+	<fieldset><div class="custom-control custom-radio"><input class="custom-control-input" type="radio" value="x" name="a" id="frm--a0" data-nette-rules="[]"><label class="custom-control-label" for="frm--a0">X</label></div><div class="custom-control custom-radio"><input class="custom-control-input" type="radio" value="y" name="a" id="frm--a1"><label class="custom-control-label" for="frm--a1">Y</label></div></fieldset>
+</div>
+<input type="hidden" name="_do" value="-submit"></form>

--- a/tests/data/vertical/select.html
+++ b/tests/data/vertical/select.html
@@ -1,0 +1,7 @@
+<form action="/" method="post" id="frm-">
+<div class="form-group">
+	<label for="frm--a">b</label>
+
+	<select name="a" id="frm--a" class="custom-select"><option value="x">X</option><option value="y">Y</option></select>
+</div>
+<input type="hidden" name="_do" value="-submit"></form>

--- a/tests/data/vertical/submit.html
+++ b/tests/data/vertical/submit.html
@@ -1,0 +1,7 @@
+<form action="/" method="post" id="frm-">
+<div class="form-group">
+	
+
+	<input type="submit" name="a" value="b" class="btn btn-primary">
+</div>
+<input type="hidden" name="_do" value="-submit"></form>

--- a/tests/data/vertical/text.html
+++ b/tests/data/vertical/text.html
@@ -1,0 +1,7 @@
+<form action="/" method="post" id="frm-">
+<div class="form-group">
+	<label for="frm--a">b</label>
+
+	<input type="text" name="a" id="frm--a" class="form-control">
+</div>
+<input type="hidden" name="_do" value="-submit"></form>

--- a/tests/data/vertical/text_description.html
+++ b/tests/data/vertical/text_description.html
@@ -1,0 +1,9 @@
+<form action="/" method="post" id="frm-">
+<div class="form-group">
+	<label for="frm--a">b</label>
+
+	<input type="text" name="a" id="frm--a" class="form-control">
+		<small class="form-text text-muted">Helpful hint</small>
+	
+</div>
+<input type="hidden" name="_do" value="-submit"></form>

--- a/tests/data/vertical/text_error.html
+++ b/tests/data/vertical/text_error.html
@@ -1,0 +1,9 @@
+<form action="/" method="post" id="frm-">
+<div class="form-group">
+	
+
+	<input type="text" name="a" id="frm--a" class="form-control is-invalid">
+		<div class="invalid-feedback">test-error<br></div>
+	
+</div>
+<input type="hidden" name="_do" value="-submit"></form>

--- a/tests/data/vertical/textarea.html
+++ b/tests/data/vertical/textarea.html
@@ -1,0 +1,7 @@
+<form action="/" method="post" id="frm-">
+<div class="form-group">
+	<label for="frm--a">b</label>
+
+	<textarea name="a" id="frm--a" class="form-control"></textarea>
+</div>
+<input type="hidden" name="_do" value="-submit"></form>


### PR DESCRIPTION
Fills the unit-coverage gaps left open by #123.

| | before | after |
| --- | --- | --- |
| Lines | 86.32% (732/848) | **96.46%** (818/848) |
| Methods | 67.35% (99/147) | **87.76%** (129/147) |
| Classes | 44.00% (11/25) | **72.00%** (18/25) |

## New test files

- **`Rendering/VerticalTest`** — snapshot tests for the vertical render mode, which had **none at all**; only side-by-side was covered. Cases are driven by a data provider, and the fixtures under `tests/data/vertical/` were generated from real rendered output through that same provider, so the two cannot drift apart. Covers text, description, checkbox, checkbox list, radio list, select, textarea, submit, control error, form-level error, grid row and hidden-field grouping.
- **`Rendering/RendererConfigTest`** — `configElem()`, the single function every drawn element passes through: `CLASS_SET` / `CLASS_ADD` / `CLASS_REMOVE`, `ATTRIBUTES`, `ELEMENT_NAME`, `CONTAINER` wrapping and the null-element case; plus grid-breakpoint, column and `groupHidden` accessors and the argument check in `renderControls()`.
- **`Rendering/GroupRenderingTest`** — form groups: label, id and container options, empty and non-visual groups being skipped, and the ordering rule below.
- **`Traits/ChoiceInputTraitTest`** — the shared disabled/selected logic behind radio, checkbox-list, select and multiselect, and each control's `showValidation()` override.
- **`Traits/BootstrapContainerTraitTest`** — the `add*()` factories that had no coverage at all: `addDateTime`, `addTime`, `addInteger`, `addFloat`, `addPassword`, `addMultiUpload`, `addColor`, `addButton`, `addInputError`.
- **`Grid/BootstrapRowTest`** — cells, element prototypes, breakpoints, owned names, and the `FakeControlTrait` surface that lets a row sit in the component tree without being a real form value.

`BootstrapFormTest` and `UploadInputTest` were extended for the few remaining uncovered accessors.

## Two behaviours found while writing these

Both are **pinned by tests rather than changed**, since this branch is tests only:

1. **`RadioInput` ignores control-level disabling.** `RadioInput::getControl()` only ever asks `isValueDisabled()` per item and never calls `isControlDisabled()`, so `$radioList->setDisabled(true)` renders a radio list the user can still click. `CheckboxListInput` emits `<fieldset disabled>` and `SelectInput` sets the attribute on the `<select>`; `RadioInput` emits nothing. The server side is unaffected — a disabled control holds no value — but the markup is wrong. `testDisablingTheWholeRadioListIsNotReflectedInTheHtml` documents it and will fail loudly once it is fixed. Happy to send the one-line fix as a follow-up.

2. **Group config forces element names.** `Cnf::GROUP` and `Cnf::GROUP_LABEL` declare `fieldset` / `legend` as `ELEMENT_NAME`, so a group container or label supplied as a different tag is renamed while keeping its attributes — `Html::el('h3', ['class' => 'fancy'])` comes out as `<legend class="fancy">`. That makes the string form of the `CONTAINER` option effectively inert.

Also worth noting: `RadioInput::showValidation()` builds a `$fieldset` local that it never returns (it returns `$control`). Output is still correct because `insert(replace: true)` mutates in place, but the variable is dead.

## Verification

`make tests` 148 passed (225 assertions) · `make phpstan` no errors · `make cs` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)