### PR TITLE
chore: upgrade PHPUnit to 11.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor/
 composer.lock
 .idea/
 .phpunit.result.cache
+.phpunit.cache/

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
   },
   "require-dev": {
     "contributte/qa": "^v0.3",
-    "phpunit/phpunit": "^9.5",
+    "phpunit/phpunit": "^11.5",
     "phpstan/phpstan": "^2.2",
     "phpstan/phpstan-deprecation-rules": "^2.0",
     "phpstan/phpstan-nette": "^2.0",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="tests/bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-  <coverage processUncoveredFiles="true">
-    <include>
-      <directory suffix=".php">src</directory>
-    </include>
-  </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="tests/bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd" cacheDirectory=".phpunit.cache">
   <testsuites>
     <testsuite name="all">
       <directory>tests</directory>
     </testsuite>
   </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </source>
 </phpunit>

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -4,7 +4,7 @@ namespace Tests;
 
 use PHPUnit\Framework\TestCase;
 
-abstract class BaseTest extends TestCase
+abstract class BaseTestCase extends TestCase
 {
 
 	public function loadTextData(string $filename): string

--- a/tests/BootstrapFormTest.php
+++ b/tests/BootstrapFormTest.php
@@ -8,7 +8,7 @@ use Contributte\FormsBootstrap\Enums\BootstrapVersion;
 use Contributte\FormsBootstrap\Enums\RenderMode;
 use Nette\Forms\Rendering\DefaultFormRenderer;
 
-class BootstrapFormTest extends BaseTest
+class BootstrapFormTest extends BaseTestCase
 {
 
 	public function testSetRendereWithWrongBootstrapRendererShouldThrowException(): void

--- a/tests/BootstrapUtilsTest.php
+++ b/tests/BootstrapUtilsTest.php
@@ -5,7 +5,7 @@ namespace Tests;
 use Contributte\FormsBootstrap\BootstrapUtils;
 use Nette\Utils\Html;
 
-class BootstrapUtilsTest extends BaseTest
+class BootstrapUtilsTest extends BaseTestCase
 {
 
 	public function testStandardizeClass(): void

--- a/tests/E2E/BaseE2ETestCase.php
+++ b/tests/E2E/BaseE2ETestCase.php
@@ -6,14 +6,14 @@ use Contributte\FormsBootstrap\BootstrapForm;
 use Nette\Application\Request as AppRequest;
 use Nette\Http;
 use ReflectionMethod;
-use Tests\BaseTest;
+use Tests\BaseTestCase;
 
 /**
  * Base for end-to-end tests: builds a real HTTP request, runs a real presenter
  * through its whole lifecycle and lets the form receive the `submit` signal
  * exactly the way it does in production.
  */
-abstract class BaseE2ETest extends BaseTest
+abstract class BaseE2ETestCase extends BaseTestCase
 {
 
 	/**

--- a/tests/E2E/FormSubmissionTest.php
+++ b/tests/E2E/FormSubmissionTest.php
@@ -9,7 +9,7 @@ use Nette\Http\FileUpload;
  * Drives whole requests through a real presenter: a form is rendered, a browser
  * posts it back and the resulting values, errors and events are checked.
  */
-class FormSubmissionTest extends BaseE2ETest
+class FormSubmissionTest extends BaseE2ETestCase
 {
 
 	public function testValidSubmitIsSuccessfulAndYieldsValues(): void

--- a/tests/E2E/ValidationStateTest.php
+++ b/tests/E2E/ValidationStateTest.php
@@ -10,7 +10,7 @@ use Contributte\FormsBootstrap\Enums\RendererOptions;
  * Submits a form that fails validation and then re-renders it, the way a
  * presenter does when it falls through to the template after onError.
  */
-class ValidationStateTest extends BaseE2ETest
+class ValidationStateTest extends BaseE2ETestCase
 {
 
 	public function testInvalidControlIsMarkedAndCarriesItsMessage(): void

--- a/tests/Grid/BootstrapCellTest.php
+++ b/tests/Grid/BootstrapCellTest.php
@@ -7,9 +7,9 @@ use Contributte\FormsBootstrap\Grid\BootstrapCell;
 use Contributte\FormsBootstrap\Grid\BootstrapRow;
 use Nette\Application\UI\Presenter;
 use Nette\InvalidArgumentException;
-use Tests\BaseTest;
+use Tests\BaseTestCase;
 
-class BootstrapCellTest extends BaseTest
+class BootstrapCellTest extends BaseTestCase
 {
 
 	/** @var BootstrapCell */

--- a/tests/Grid/BootstrapGroupRowRenderingTest.php
+++ b/tests/Grid/BootstrapGroupRowRenderingTest.php
@@ -6,9 +6,9 @@ use Contributte\FormsBootstrap\BootstrapForm;
 use Contributte\FormsBootstrap\BootstrapRenderer;
 use Contributte\FormsBootstrap\Enums\RenderMode;
 use Nette\Application\UI\Presenter;
-use Tests\BaseTest;
+use Tests\BaseTestCase;
 
-class BootstrapGroupRowRenderingTest extends BaseTest
+class BootstrapGroupRowRenderingTest extends BaseTestCase
 {
 
 	public function testGroupRowRendering(): void

--- a/tests/Grid/BootstrapRowTest.php
+++ b/tests/Grid/BootstrapRowTest.php
@@ -7,13 +7,13 @@ use Contributte\FormsBootstrap\Grid\BootstrapCell;
 use Contributte\FormsBootstrap\Grid\BootstrapRow;
 use Nette\Application\UI\Presenter;
 use Nette\NotImplementedException;
-use Tests\BaseTest;
+use Tests\BaseTestCase;
 
 /**
  * The row/cell objects themselves, and the "fake control" surface that lets a
  * row sit in the component tree without being a real form value.
  */
-class BootstrapRowTest extends BaseTest
+class BootstrapRowTest extends BaseTestCase
 {
 
 	private BootstrapForm $form;

--- a/tests/Inputs/ButtonInputTest.php
+++ b/tests/Inputs/ButtonInputTest.php
@@ -3,9 +3,9 @@
 namespace Tests\Inputs;
 
 use Contributte\FormsBootstrap\BootstrapForm;
-use Tests\BaseTest;
+use Tests\BaseTestCase;
 
-class ButtonInputTest extends BaseTest
+class ButtonInputTest extends BaseTestCase
 {
 
 	public function testDefaultButton(): void

--- a/tests/Inputs/CheckBoxListTest.php
+++ b/tests/Inputs/CheckBoxListTest.php
@@ -4,9 +4,9 @@ namespace Tests\Inputs;
 
 use Contributte\FormsBootstrap\BootstrapForm;
 use Contributte\FormsBootstrap\Enums\BootstrapVersion;
-use Tests\BaseTest;
+use Tests\BaseTestCase;
 
-class CheckBoxListTest extends BaseTest
+class CheckBoxListTest extends BaseTestCase
 {
 
 	public function testSetItemsWithKeysAndValueIntegers(): void

--- a/tests/Inputs/CheckboxInputTest.php
+++ b/tests/Inputs/CheckboxInputTest.php
@@ -5,9 +5,9 @@ namespace Tests\Inputs;
 use Contributte\FormsBootstrap\BootstrapForm;
 use Contributte\FormsBootstrap\Enums\BootstrapVersion;
 use Nette\Utils\Html;
-use Tests\BaseTest;
+use Tests\BaseTestCase;
 
-class CheckboxInputTest extends BaseTest
+class CheckboxInputTest extends BaseTestCase
 {
 
 	public function testHtmlCaption(): void

--- a/tests/Inputs/ColorPickerTest.php
+++ b/tests/Inputs/ColorPickerTest.php
@@ -3,9 +3,9 @@
 namespace Tests\Inputs;
 
 use Contributte\FormsBootstrap\BootstrapForm;
-use Tests\BaseTest;
+use Tests\BaseTestCase;
 
-class ColorPickerTest extends BaseTest
+class ColorPickerTest extends BaseTestCase
 {
 
 	public function testDefaultTextInput(): void

--- a/tests/Inputs/DateInputTest.php
+++ b/tests/Inputs/DateInputTest.php
@@ -5,9 +5,9 @@ namespace Tests\Inputs;
 use Contributte\FormsBootstrap\BootstrapForm;
 use Contributte\FormsBootstrap\Enums\DateTimeFormat;
 use Contributte\FormsBootstrap\Inputs\DateInput;
-use Tests\BaseTest;
+use Tests\BaseTestCase;
 
-class DateInputTest extends BaseTest
+class DateInputTest extends BaseTestCase
 {
 
 	public function testDefaultDate(): void

--- a/tests/Inputs/DateTimeControlTest.php
+++ b/tests/Inputs/DateTimeControlTest.php
@@ -3,9 +3,9 @@
 namespace Tests\Inputs;
 
 use Contributte\FormsBootstrap\BootstrapForm;
-use Tests\BaseTest;
+use Tests\BaseTestCase;
 
-class DateTimeControlTest extends BaseTest
+class DateTimeControlTest extends BaseTestCase
 {
 
 	public function testDefaultDate(): void

--- a/tests/Inputs/DateTimeInputTest.php
+++ b/tests/Inputs/DateTimeInputTest.php
@@ -6,9 +6,9 @@ use Contributte\FormsBootstrap\BootstrapForm;
 use Contributte\FormsBootstrap\Inputs\DateInput;
 use Contributte\FormsBootstrap\Inputs\DateTimeInput;
 use DateTime;
-use Tests\BaseTest;
+use Tests\BaseTestCase;
 
-class DateTimeInputTest extends BaseTest
+class DateTimeInputTest extends BaseTestCase
 {
 
 	public function testDefaultDateTime(): void

--- a/tests/Inputs/MultiSelectInputTest.php
+++ b/tests/Inputs/MultiSelectInputTest.php
@@ -4,9 +4,9 @@ namespace Tests\Inputs;
 
 use Contributte\FormsBootstrap\BootstrapForm;
 use Contributte\FormsBootstrap\Enums\BootstrapVersion;
-use Tests\BaseTest;
+use Tests\BaseTestCase;
 
-class MultiSelectInputTest extends BaseTest
+class MultiSelectInputTest extends BaseTestCase
 {
 
 	public function testMultiSelect(): void

--- a/tests/Inputs/RadioInputTest.php
+++ b/tests/Inputs/RadioInputTest.php
@@ -4,9 +4,9 @@ namespace Tests\Inputs;
 
 use Contributte\FormsBootstrap\BootstrapForm;
 use Contributte\FormsBootstrap\Enums\BootstrapVersion;
-use Tests\BaseTest;
+use Tests\BaseTestCase;
 
-class RadioInputTest extends BaseTest
+class RadioInputTest extends BaseTestCase
 {
 
 	public function testRadioInput(): void

--- a/tests/Inputs/SelectInputTest.php
+++ b/tests/Inputs/SelectInputTest.php
@@ -5,9 +5,9 @@ namespace Tests\Inputs;
 use Contributte\FormsBootstrap\BootstrapForm;
 use Contributte\FormsBootstrap\Enums\BootstrapVersion;
 use Nette\InvalidArgumentException;
-use Tests\BaseTest;
+use Tests\BaseTestCase;
 
-class SelectInputTest extends BaseTest
+class SelectInputTest extends BaseTestCase
 {
 
 	public function testSetItemsWithKeysFalse(): void

--- a/tests/Inputs/TextAreaInputTest.php
+++ b/tests/Inputs/TextAreaInputTest.php
@@ -4,9 +4,9 @@ namespace Tests\Inputs;
 
 use Contributte\FormsBootstrap\BootstrapForm;
 use Nette\Utils\Html;
-use Tests\BaseTest;
+use Tests\BaseTestCase;
 
-class TextAreaInputTest extends BaseTest
+class TextAreaInputTest extends BaseTestCase
 {
 
 	public function testDefaultTextAreaInput(): void

--- a/tests/Inputs/TextInputTest.php
+++ b/tests/Inputs/TextInputTest.php
@@ -3,9 +3,9 @@
 namespace Tests\Inputs;
 
 use Contributte\FormsBootstrap\BootstrapForm;
-use Tests\BaseTest;
+use Tests\BaseTestCase;
 
-class TextInputTest extends BaseTest
+class TextInputTest extends BaseTestCase
 {
 
 	public function testDefaultTextInput(): void

--- a/tests/Inputs/UploadInputTest.php
+++ b/tests/Inputs/UploadInputTest.php
@@ -4,9 +4,9 @@ namespace Tests\Inputs;
 
 use Contributte\FormsBootstrap\BootstrapForm;
 use Contributte\FormsBootstrap\Enums\BootstrapVersion;
-use Tests\BaseTest;
+use Tests\BaseTestCase;
 
-class UploadInputTest extends BaseTest
+class UploadInputTest extends BaseTestCase
 {
 
 	public function testDefaultButton(): void

--- a/tests/Rendering/GroupRenderingTest.php
+++ b/tests/Rendering/GroupRenderingTest.php
@@ -6,13 +6,13 @@ use Contributte\FormsBootstrap\BootstrapForm;
 use Contributte\FormsBootstrap\Enums\RendererOptions;
 use Nette\Application\UI\Presenter;
 use Nette\Utils\Html;
-use Tests\BaseTest;
+use Tests\BaseTestCase;
 
 /**
  * Form groups: the renderer draws them before any loose controls and honours
  * the label, id and container options set on them.
  */
-class GroupRenderingTest extends BaseTest
+class GroupRenderingTest extends BaseTestCase
 {
 
 	private BootstrapForm $form;

--- a/tests/Rendering/RendererConfigTest.php
+++ b/tests/Rendering/RendererConfigTest.php
@@ -9,13 +9,13 @@ use Contributte\FormsBootstrap\Enums\RenderMode;
 use Nette\Application\UI\Presenter;
 use Nette\InvalidArgumentException;
 use Nette\Utils\Html;
-use Tests\BaseTest;
+use Tests\BaseTestCase;
 
 /**
  * Exercises configElem() — the one function every drawn element goes through —
  * and the renderer's own accessors.
  */
-class RendererConfigTest extends BaseTest
+class RendererConfigTest extends BaseTestCase
 {
 
 	private BootstrapRenderer $renderer;

--- a/tests/Rendering/SideBySideTest.php
+++ b/tests/Rendering/SideBySideTest.php
@@ -6,9 +6,9 @@ use Contributte\FormsBootstrap\BootstrapForm;
 use Contributte\FormsBootstrap\BootstrapRenderer;
 use Contributte\FormsBootstrap\Enums\RenderMode;
 use Nette\Application\UI\Presenter;
-use Tests\BaseTest;
+use Tests\BaseTestCase;
 
-class SideBySideTest extends BaseTest
+class SideBySideTest extends BaseTestCase
 {
 
 	/** @var BootstrapForm */

--- a/tests/Rendering/VerticalTest.php
+++ b/tests/Rendering/VerticalTest.php
@@ -6,13 +6,14 @@ use Contributte\FormsBootstrap\BootstrapForm;
 use Contributte\FormsBootstrap\BootstrapRenderer;
 use Contributte\FormsBootstrap\Enums\RenderMode;
 use Nette\Application\UI\Presenter;
-use Tests\BaseTest;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\BaseTestCase;
 
 /**
  * Snapshot tests for the vertical render mode, the renderer's default.
  * Side-by-side is covered by SideBySideTest.
  */
-class VerticalTest extends BaseTest
+class VerticalTest extends BaseTestCase
 {
 
 	/** @var BootstrapForm */
@@ -92,9 +93,9 @@ class VerticalTest extends BaseTest
 	}
 
 	/**
-	 * @dataProvider provideForms
 	 * @param callable(BootstrapForm): void $build
 	 */
+	#[DataProvider('provideForms')]
 	public function testRendering(string $fixture, callable $build): void
 	{
 		$build($this->form);

--- a/tests/Traits/BootstrapContainerTraitTest.php
+++ b/tests/Traits/BootstrapContainerTraitTest.php
@@ -6,12 +6,12 @@ use Contributte\FormsBootstrap\BootstrapForm;
 use Contributte\FormsBootstrap\Inputs\DateTimeControl;
 use Contributte\FormsBootstrap\Inputs\TextInput;
 use Contributte\FormsBootstrap\Inputs\UploadInput;
-use Tests\BaseTest;
+use Tests\BaseTestCase;
 
 /**
  * The add*() factories that BootstrapForm and BootstrapContainer share.
  */
-class BootstrapContainerTraitTest extends BaseTest
+class BootstrapContainerTraitTest extends BaseTestCase
 {
 
 	public function testAddDateTimeProducesDateTimeLocalInput(): void

--- a/tests/Traits/ChoiceInputTraitTest.php
+++ b/tests/Traits/ChoiceInputTraitTest.php
@@ -4,13 +4,13 @@ namespace Tests\Traits;
 
 use Contributte\FormsBootstrap\BootstrapForm;
 use Nette\Utils\Html;
-use Tests\BaseTest;
+use Tests\BaseTestCase;
 
 /**
  * The disabled/selected logic shared by radio, checkbox-list and select,
  * observed through the HTML those controls render.
  */
-class ChoiceInputTraitTest extends BaseTest
+class ChoiceInputTraitTest extends BaseTestCase
 {
 
 	/**


### PR DESCRIPTION
Bumps `phpunit/phpunit` from `^9.5` to `^11.5` — the newest major that still runs on **PHP 8.2**, this library's minimum. PHPUnit 12 requires PHP 8.3 and 13 requires 8.4.1, so either would force the dev floor above the runtime floor.

### Changes

- `composer.json`: `phpunit/phpunit` `^9.5` → `^11.5` (installs 11.5.56)
- `phpunit.xml`: migrated to the 11.5 schema via `--migrate-configuration` — `<coverage>` splits into `<source>`, the removed `processUncoveredFiles` attribute is gone, and `cacheDirectory` is set
- `.gitignore`: ignore the new `.phpunit.cache/` directory
- Renamed the abstract bases `BaseTest` → `BaseTestCase` and `BaseE2ETest` → `BaseE2ETestCase`; PHPUnit 11's runner warns on abstract classes named `*Test`, and the warning makes `make tests` exit non-zero
- `VerticalTest`: `@dataProvider` doc-comment → `#[DataProvider]` attribute; doc-comment metadata is deprecated in 11 and removed in 12

No production code touched — `src/` is unchanged.

### Verification

`make tests` → 148 tests, 225 assertions, no warnings or deprecations. `make cs` and `make phpstan` both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)