### PR TITLE
chore: upgrade contributte/qa to 0.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "nette/application": "^3.0"
   },
   "require-dev": {
-    "contributte/qa": "^v0.3",
+    "contributte/qa": "^v0.4",
     "phpunit/phpunit": "^11.5",
     "phpstan/phpstan": "^2.2",
     "phpstan/phpstan-deprecation-rules": "^2.0",

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -16,10 +16,10 @@
     <!-- Specific rules -->
     <rule ref="SlevomatCodingStandard.Files.TypeNameMatchesFileName">
         <properties>
-            <property name="rootNamespaces" type="array" value="
-				src=>Contributte\FormsBootstrap,
-				tests=>Tests,
-			"/>
+            <property name="rootNamespaces" type="array">
+                <element key="src" value="Contributte\FormsBootstrap"/>
+                <element key="tests" value="Tests"/>
+            </property>
         </properties>
     </rule>
 </ruleset>


### PR DESCRIPTION
Bumps `contributte/qa` from `^v0.3` to `^v0.4` (v0.3.2 => v0.4.0).

Transitive updates pulled in:

- `squizlabs/php_codesniffer` 3.13.5 => 3.13.6
- `phpstan/phpdoc-parser` 2.3.2 => 2.3.3

## Ruleset fix

The newer PHPCS warns on our own `ruleset.xml`:

> Passing an array of values to a property using a comma-separated string was deprecated in PHP_CodeSniffer 3.3.0. Support will be removed in PHPCS 4.0.0. The deprecated syntax was used for property `rootNamespaces` for sniff `SlevomatCodingStandard.Files.TypeNameMatchesFileName`.

Rewritten using `<element key="..." value="..."/>` nodes. The sniff still applies to `src/` and `tests/` as before, and the warning is gone.

## Notes

No source changes were needed — the v0.4 ruleset flags nothing in `src/` or `tests/`.

v0.5 exists only as `0.5.x-dev`, so `^v0.4` is the current stable ceiling.

## Verification

Run locally on PHP 8.3.31:

- `make phpstan` — no errors (level 7, `src/`)
- `make cs` — 64/64 files, no warnings
- `make tests` — 148 tests, 225 assertions, all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)