### PR TITLE
fix: honour setDisabled(true) on RadioInput

### DIFF
--- a/src/Inputs/RadioInput.php
+++ b/src/Inputs/RadioInput.php
@@ -46,6 +46,9 @@ class RadioInput extends RadioList implements IValidationInput
 
 		$items = $this->getItems();
 		$container = $this->container;
+		// one attribute on the fieldset disables every radio inside it, the same
+		// way CheckboxListInput handles a wholly disabled control
+		$container->setAttribute('disabled', $this->isControlDisabled());
 
 		$c = 0;
 		$htmlId = $this->getHtmlId();

--- a/tests/E2E/FormSubmissionTest.php
+++ b/tests/E2E/FormSubmissionTest.php
@@ -261,6 +261,25 @@ class FormSubmissionTest extends BaseE2ETestCase
 		$this->assertNull($form['country']->getValue());
 	}
 
+	public function testWhollyDisabledRadioListIsRenderedDisabledAndRejectsItsPost(): void
+	{
+		$form = $this->submit(
+			function (): BootstrapForm {
+				$form = new BootstrapForm();
+				$form->setAction('/');
+				$form->addRadioList('size', 'Size', ['s' => 'Small', 'l' => 'Large'])
+					->setDisabled(true);
+				$form->addSubmit('send');
+
+				return $form;
+			},
+			['size' => 's']
+		);
+
+		$this->assertNull($form['size']->getValue());
+		$this->assertStringContainsString('<fieldset disabled>', (string) $form['size']->getControl());
+	}
+
 	public function testCheckboxListCollectsEveryCheckedValue(): void
 	{
 		$form = $this->submit(

--- a/tests/Inputs/RadioInputTest.php
+++ b/tests/Inputs/RadioInputTest.php
@@ -16,6 +16,22 @@ class RadioInputTest extends BaseTestCase
 		$this->assertEquals('<fieldset><div class="custom-control custom-radio"><input class="custom-control-input" type="radio" value="1" name="txt" id="frm-txt0" data-nette-rules="[]"><label class="custom-control-label" for="frm-txt0">1</label></div><div class="custom-control custom-radio"><input class="custom-control-input" type="radio" value="2" name="txt" id="frm-txt1"><label class="custom-control-label" for="frm-txt1">2</label></div></fieldset>', (string) $input->getControl());
 	}
 
+	public function testDisabledRadioInput(): void
+	{
+		$form = new BootstrapForm();
+		$input = $form->addRadioList('txt', 'lbl', [1 => '1', 2 => '2']);
+		$input->setDisabled(true);
+		$this->assertEquals('<fieldset disabled><div class="custom-control custom-radio"><input class="custom-control-input" type="radio" value="1" name="txt" id="frm-txt0" data-nette-rules="[]"><label class="custom-control-label" for="frm-txt0">1</label></div><div class="custom-control custom-radio"><input class="custom-control-input" type="radio" value="2" name="txt" id="frm-txt1"><label class="custom-control-label" for="frm-txt1">2</label></div></fieldset>', (string) $input->getControl());
+	}
+
+	public function testRadioInputWithSingleDisabledItem(): void
+	{
+		$form = new BootstrapForm();
+		$input = $form->addRadioList('txt', 'lbl', [1 => '1', 2 => '2']);
+		$input->setDisabled([1]);
+		$this->assertEquals('<fieldset><div class="custom-control custom-radio"><input class="custom-control-input" type="radio" value="1" name="txt" disabled id="frm-txt0" data-nette-rules="[]"><label class="custom-control-label" for="frm-txt0">1</label></div><div class="custom-control custom-radio"><input class="custom-control-input" type="radio" value="2" name="txt" id="frm-txt1"><label class="custom-control-label" for="frm-txt1">2</label></div></fieldset>', (string) $input->getControl());
+	}
+
 	public function testRadioInputV5(): void
 	{
 		BootstrapForm::switchBootstrapVersion(BootstrapVersion::V5);

--- a/tests/Traits/ChoiceInputTraitTest.php
+++ b/tests/Traits/ChoiceInputTraitTest.php
@@ -13,20 +13,39 @@ use Tests\BaseTestCase;
 class ChoiceInputTraitTest extends BaseTestCase
 {
 
-	/**
-	 * Known gap: RadioInput::getControl() only ever asks isValueDisabled() per
-	 * item and never calls isControlDisabled(), so a radio list disabled as a
-	 * whole still renders as interactive. CheckboxListInput and SelectInput both
-	 * put the attribute on their element. Pinned here so that fixing RadioInput
-	 * shows up as a failure of this test rather than going unnoticed.
-	 */
-	public function testDisablingTheWholeRadioListIsNotReflectedInTheHtml(): void
+	public function testWholeRadioListIsDisabledThroughItsFieldset(): void
 	{
 		$form = new BootstrapForm();
 		$radio = $form->addRadioList('a', 'b', ['x' => 'X', 'y' => 'Y']);
 		$radio->setDisabled(true);
 
+		$html = (string) $radio->getControl();
+
+		// one attribute on the fieldset disables every radio inside it
+		$this->assertStringStartsWith('<fieldset disabled>', $html);
+		$this->assertSame(1, substr_count($html, 'disabled'));
+	}
+
+	public function testReEnablingTheWholeRadioListDropsTheAttributeAgain(): void
+	{
+		$form = new BootstrapForm();
+		$radio = $form->addRadioList('a', 'b', ['x' => 'X', 'y' => 'Y']);
+		$radio->setDisabled(true);
+		$radio->setDisabled(false);
+
 		$this->assertStringNotContainsString('disabled', (string) $radio->getControl());
+	}
+
+	public function testDisabledRadioListKeepsItsFieldsetAttributeThroughValidationState(): void
+	{
+		$form = new BootstrapForm();
+		$radio = $form->addRadioList('a', 'b', ['x' => 'X', 'y' => 'Y']);
+		$radio->setDisabled(true);
+		$radio->addError('nope');
+
+		$html = (string) $radio->showValidation($radio->getControl());
+
+		$this->assertStringStartsWith('<fieldset disabled>', $html);
 	}
 
 	public function testDisablingRadioListClearsWhateverWasSelected(): void


### PR DESCRIPTION
Closes #112.

## The bug

`RadioInput::getControl()` decided each item's `disabled` attribute purely from `isValueDisabled()`, and that helper returns `false` whenever the control is disabled as a whole (it only inspects the array form). Nothing else consulted `isControlDisabled()`, so `setDisabled(true)` on a radio list rendered markup with no `disabled` anywhere — the list looked and behaved as fully interactive, contrary to the `bool|array` signature.

Nette still refused the posted value server-side, so this was a rendering defect rather than a security hole, but the user-visible behaviour was wrong.

## The fix

Set the attribute on the `fieldset` container, which `RadioInput` already uses as its container prototype:

```php
$container->setAttribute('disabled', $this->isControlDisabled());
```

This mirrors `CheckboxListInput`, which puts `'disabled' => $this->isControlDisabled()` on its own fieldset — one attribute disables every control inside it, and per-item disabling via `setDisabled(['x'])` keeps working unchanged.

## Tests

`tests/Traits/ChoiceInputTraitTest.php` carried a test that deliberately pinned this gap (`testDisablingTheWholeRadioListIsNotReflectedInTheHtml`) so a fix would surface as a failure. That test is replaced by one asserting the correct behaviour, plus:

- re-enabling with `setDisabled(false)` drops the attribute again
- the attribute survives `showValidation()`
- exact-HTML assertions in `tests/Inputs/RadioInputTest.php` for both the wholly-disabled and single-item-disabled cases
- an E2E case in `tests/E2E/FormSubmissionTest.php` covering render + rejected post together

`make tests` (155 tests), `make phpstan` and `make cs` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)