### PR TITLE
chore: support nette/forms 3.3.0, require PHP 8.3

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,4 +19,4 @@ jobs:
     uses: contributte/.github/.github/workflows/nette-tester-coverage-v2.yml@master
     secrets: inherit
     with:
-      php: "8.2"
+      php: "8.3"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -23,7 +23,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: [ "8.2" ]
+        php-version: [ "8.3" ]
         operating-system: [ "ubuntu-latest" ]
       fail-fast: false
 
@@ -82,7 +82,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: [ "8.2" ]
+        php-version: [ "8.3" ]
         operating-system: [ "ubuntu-latest" ]
       fail-fast: false
 
@@ -138,16 +138,13 @@ jobs:
 
     strategy:
       matrix:
-        php-version: ["8.2", "8.3", "8.4","8.5"]
+        php-version: ["8.3", "8.4", "8.5"]
         operating-system: [ "ubuntu-latest" ]
         composer-args: [ "" ]
         include:
-          - php-version: "8.2"
-            operating-system: "ubuntu-latest"
-            composer-args: "--prefer-lowest"
           - php-version: "8.3"
             operating-system: "ubuntu-latest"
-            composer-args: "--ignore-platform-reqs"
+            composer-args: "--prefer-lowest"
       fail-fast: false
 
     steps:

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Nette extension for Bootstrap forms.
 
 | State       | Version       | Branch   | Nette | PHP     | Bootstrap   |
 |-------------|---------------|----------|-------|---------|-------------|
-| dev         | `^0.9`        | `master` | 3.3+  | `^8.2`  | `4.x` `5.x` |
+| dev         | `^0.9`        | `master` | 3.3+  | `^8.3`  | `4.x` `5.x` |
 | stable      | `^0.8`        | `master` | 3.0+  | `^8.1`  | `4.x` `5.x` |
 | stable      | `^0.7`        | `master` | 3.0+  | `^8.1`  | `4.x` `5.x` |
 | stable      | `^0.6`        | `master` | 3.0+  | `^8.1`  | `4.x` `5.x` |

--- a/composer.json
+++ b/composer.json
@@ -17,13 +17,13 @@
     }
   ],
   "require": {
-    "php": ">=8.2",
-    "nette/forms": "3.3.0",
+    "php": ">=8.3",
+    "nette/forms": "^3.3.0",
     "nette/application": "^3.0"
   },
   "require-dev": {
     "contributte/qa": "^v0.4",
-    "phpunit/phpunit": "^11.5",
+    "phpunit/phpunit": "^12.5",
     "phpstan/phpstan": "^2.2",
     "phpstan/phpstan-deprecation-rules": "^2.0",
     "phpstan/phpstan-nette": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   ],
   "require": {
     "php": ">=8.2",
-    "nette/forms": "3.2.9",
+    "nette/forms": "3.3.0",
     "nette/application": "^3.0"
   },
   "require-dev": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="tests/bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd" cacheDirectory=".phpunit.cache">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="tests/bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.5/phpunit.xsd" cacheDirectory=".phpunit.cache">
   <testsuites>
     <testsuite name="all">
       <directory>tests</directory>

--- a/src/BootstrapRenderer.php
+++ b/src/BootstrapRenderer.php
@@ -509,7 +509,7 @@ class BootstrapRenderer implements FormRenderer
 	 */
 	public function renderLabel(BaseControl $control): Html
 	{
-		if ($control->caption === null) {
+		if ($control->getCaption() === null) {
 			return Html::el();
 		}
 

--- a/src/Grid/BootstrapCell.php
+++ b/src/Grid/BootstrapCell.php
@@ -91,7 +91,7 @@ class BootstrapCell
 		$element = $this->elementPrototype;
 
 		/** @var BootstrapRenderer $renderer */
-		$renderer = $this->row->getParent()->form->renderer;
+		$renderer = $this->row->getParent()->getForm()->getRenderer();
 
 		$element = $renderer->configElem(RendererConfig::GRID_CELL, $element);
 		$element->class[] = $this->createClass();

--- a/src/Grid/BootstrapRow.php
+++ b/src/Grid/BootstrapRow.php
@@ -210,7 +210,7 @@ class BootstrapRow implements IComponent, Control
 	public function render(): Html
 	{
 		/** @var BootstrapRenderer $renderer */
-		$renderer = $this->container->form->renderer;
+		$renderer = $this->container->getForm()->getRenderer();
 
 		$element = $renderer->configElem(RendererConfig::GRID_ROW, $this->elementPrototype);
 		foreach ($this->cells as $cell) {

--- a/src/Inputs/ButtonInput.php
+++ b/src/Inputs/ButtonInput.php
@@ -35,7 +35,7 @@ class ButtonInput extends Button
 		$btn = parent::getControl($content);
 		$btn->setName('button');
 		$this->addBtnClass($btn);
-		$btn->setHtml($content ?? (string) $this->caption);
+		$btn->setHtml($content ?? (string) $this->getCaption());
 		$btn->removeAttribute('value');
 
 		return $btn;

--- a/src/Inputs/CheckboxInput.php
+++ b/src/Inputs/CheckboxInput.php
@@ -95,7 +95,7 @@ class CheckboxInput extends Checkbox implements IValidationInput
 		return self::makeCheckbox(
 			$this->getHtmlName(),
 			$this->getHtmlId(),
-			$this->translate($this->caption),
+			$this->translate($this->getCaption()),
 			$this->value,
 			false,
 			$this->required,

--- a/src/Traits/BootstrapContainerTrait.php
+++ b/src/Traits/BootstrapContainerTrait.php
@@ -2,6 +2,7 @@
 
 namespace Contributte\FormsBootstrap\Traits;
 
+use Closure;
 use Contributte\FormsBootstrap\BootstrapContainer;
 use Contributte\FormsBootstrap\BootstrapForm;
 use Contributte\FormsBootstrap\Inputs\ButtonInput;
@@ -294,13 +295,18 @@ trait BootstrapContainerTrait
 
 	/**
 	 * @param string|Html|null $caption
+	 * @param Closure|null $onSubmit handler bound to the button's onClick, added in nette/forms 3.3
 	 * @return SubmitButtonInput
 	 */
-	public function addSubmit(string $name, $caption = null): SubmitButton
+	public function addSubmit(string $name, $caption = null, ?Closure $onSubmit = null): SubmitButton
 	{
 		$comp = new SubmitButtonInput($caption);
 		$comp->setBtnClass('btn-primary');
 		$this->addComponent($comp, $name);
+
+		if ($onSubmit !== null) {
+			$comp->onClick[] = $onSubmit;
+		}
 
 		return $comp;
 	}

--- a/tests/E2E/FormSubmissionTest.php
+++ b/tests/E2E/FormSubmissionTest.php
@@ -2,7 +2,9 @@
 
 namespace Tests\E2E;
 
+use ArrayObject;
 use Contributte\FormsBootstrap\BootstrapForm;
+use Nette\Forms\Controls\SubmitButton;
 use Nette\Http\FileUpload;
 
 /**
@@ -39,6 +41,28 @@ class FormSubmissionTest extends BaseE2ETestCase
 			$this->presenter->succeededWith
 		);
 		$this->assertFalse($this->presenter->errored);
+	}
+
+	public function testAddSubmitHandlerIsCalledWhenThatButtonSubmitsTheForm(): void
+	{
+		// an object, so the closures below can share it without capturing by reference
+		$seen = new ArrayObject();
+
+		$this->submit(
+			function () use ($seen): BootstrapForm {
+				$form = new BootstrapForm();
+				$form->setAction('/');
+				$form->addText('name', 'Name');
+				$form->addSubmit('send', 'Send', function (SubmitButton $button) use ($seen): void {
+					$seen['values'] = $button->getForm()->getValues('array');
+				});
+
+				return $form;
+			},
+			['name' => 'Dalibor', 'send' => 'Send']
+		);
+
+		$this->assertSame(['name' => 'Dalibor'], $seen['values'] ?? null);
 	}
 
 	public function testMissingRequiredValueFailsValidation(): void

--- a/tests/Grid/BootstrapCellTest.php
+++ b/tests/Grid/BootstrapCellTest.php
@@ -56,7 +56,7 @@ class BootstrapCellTest extends BaseTestCase
 		$this->form = new BootstrapForm();
 		$this->row = $this->form->addRow();
 		$this->cell = $this->row->addCell(12);
-		$this->form->setParent($this->createMock(Presenter::class));
+		$this->form->setParent($this->createStub(Presenter::class));
 		// A real (non-empty) action makes Nette inject the "_do" signal field,
 		// mirroring production where the form is attached to a routed presenter.
 		$this->form->setAction('/');

--- a/tests/Grid/BootstrapGroupRowRenderingTest.php
+++ b/tests/Grid/BootstrapGroupRowRenderingTest.php
@@ -35,7 +35,7 @@ class BootstrapGroupRowRenderingTest extends BaseTestCase
 		$form->addGroup('Group 1', false)
 			->add([$row1]);
 		$form->setRenderer(new BootstrapRenderer(RenderMode::SIDE_BY_SIDE_MODE));
-		$form->setParent($this->createMock(Presenter::class));
+		$form->setParent($this->createStub(Presenter::class));
 		// A real (non-empty) action makes Nette inject the "_do" signal field,
 		// mirroring production where the form is attached to a routed presenter.
 		$form->setAction('/');

--- a/tests/Grid/BootstrapRowTest.php
+++ b/tests/Grid/BootstrapRowTest.php
@@ -117,7 +117,7 @@ class BootstrapRowTest extends BaseTestCase
 	{
 		$this->form = new BootstrapForm();
 		$this->row = $this->form->addRow();
-		$this->form->setParent($this->createMock(Presenter::class));
+		$this->form->setParent($this->createStub(Presenter::class));
 		// A real (non-empty) action makes Nette inject the "_do" signal field,
 		// mirroring production where the form is attached to a routed presenter.
 		$this->form->setAction('/');

--- a/tests/Inputs/ColorPickerTest.php
+++ b/tests/Inputs/ColorPickerTest.php
@@ -22,7 +22,7 @@ class ColorPickerTest extends BaseTestCase
 	{
 		$form = new BootstrapForm();
 		// Rendering a form requires a presenter with a non-empty action; see BaseTestCase users.
-		$form->setParent($this->createMock(Presenter::class));
+		$form->setParent($this->createStub(Presenter::class));
 		$form->setAction('/');
 
 		$input = $form->addColor('color', 'Choose color');

--- a/tests/Inputs/DateTimeControlTest.php
+++ b/tests/Inputs/DateTimeControlTest.php
@@ -21,7 +21,7 @@ class DateTimeControlTest extends BaseTestCase
 	{
 		$form = new BootstrapForm();
 		// Rendering a form requires a presenter with a non-empty action; see BaseTestCase users.
-		$form->setParent($this->createMock(Presenter::class));
+		$form->setParent($this->createStub(Presenter::class));
 		$form->setAction('/');
 
 		$dt = $form->addDate('date', 'Date');

--- a/tests/Rendering/GroupRenderingTest.php
+++ b/tests/Rendering/GroupRenderingTest.php
@@ -125,7 +125,7 @@ class GroupRenderingTest extends BaseTestCase
 	protected function setUp(): void
 	{
 		$this->form = new BootstrapForm();
-		$this->form->setParent($this->createMock(Presenter::class));
+		$this->form->setParent($this->createStub(Presenter::class));
 		// A real (non-empty) action makes Nette inject the "_do" signal field,
 		// mirroring production where the form is attached to a routed presenter.
 		$this->form->setAction('/');

--- a/tests/Rendering/RendererConfigTest.php
+++ b/tests/Rendering/RendererConfigTest.php
@@ -149,7 +149,7 @@ class RendererConfigTest extends BaseTestCase
 	public function testHiddenFieldsStayInPlaceWhenGroupingIsOff(): void
 	{
 		$form = new BootstrapForm();
-		$form->setParent($this->createMock(Presenter::class));
+		$form->setParent($this->createStub(Presenter::class));
 		$form->setAction('/');
 		$form->getRenderer()->setGroupHidden(false);
 		$form->addHidden('secret', 'v');
@@ -189,7 +189,7 @@ class RendererConfigTest extends BaseTestCase
 	{
 		$form = new BootstrapForm();
 		$form->setRenderer(new BootstrapRenderer(RenderMode::SIDE_BY_SIDE_MODE));
-		$form->setParent($this->createMock(Presenter::class));
+		$form->setParent($this->createStub(Presenter::class));
 		$form->setAction('/');
 
 		return $form;

--- a/tests/Rendering/SideBySideTest.php
+++ b/tests/Rendering/SideBySideTest.php
@@ -92,7 +92,7 @@ class SideBySideTest extends BaseTestCase
 	{
 		$this->form = new BootstrapForm();
 		$this->form->setRenderer(new BootstrapRenderer(RenderMode::SIDE_BY_SIDE_MODE));
-		$this->form->setParent($this->createMock(Presenter::class));
+		$this->form->setParent($this->createStub(Presenter::class));
 		// A real (non-empty) action makes Nette inject the "_do" signal field,
 		// mirroring production where the form is attached to a routed presenter.
 		$this->form->setAction('/');

--- a/tests/Rendering/VerticalTest.php
+++ b/tests/Rendering/VerticalTest.php
@@ -114,7 +114,7 @@ class VerticalTest extends BaseTestCase
 	{
 		$this->form = new BootstrapForm();
 		$this->form->setRenderer(new BootstrapRenderer(RenderMode::VERTICAL_MODE));
-		$this->form->setParent($this->createMock(Presenter::class));
+		$this->form->setParent($this->createStub(Presenter::class));
 		// A real (non-empty) action makes Nette inject the "_do" signal field,
 		// mirroring production where the form is attached to a routed presenter.
 		$this->form->setAction('/');

--- a/tests/Traits/BootstrapContainerTraitTest.php
+++ b/tests/Traits/BootstrapContainerTraitTest.php
@@ -122,6 +122,29 @@ class BootstrapContainerTraitTest extends BaseTestCase
 		$this->assertStringNotContainsString('type="submit"', $html);
 	}
 
+	public function testAddSubmitWithoutHandlerRegistersNoClickListener(): void
+	{
+		$form = new BootstrapForm();
+		$button = $form->addSubmit('send', 'Send');
+
+		$this->assertStringContainsString('type="submit"', (string) $button->getControl());
+		$this->assertSame([], $button->onClick);
+	}
+
+	/**
+	 * nette/forms 3.3 grew a third addSubmit() argument that wires a handler
+	 * straight onto the button's onClick.
+	 */
+	public function testAddSubmitTakesAnOnSubmitHandler(): void
+	{
+		$form = new BootstrapForm();
+		$handler = function (): void {
+		};
+		$button = $form->addSubmit('send', 'Send', $handler);
+
+		$this->assertSame([$handler], $button->onClick);
+	}
+
 	public function testFactoriesAlsoWorkInsideContainer(): void
 	{
 		$form = new BootstrapForm();


### PR DESCRIPTION
Closes #118.

## What broke

Installing `nette/forms` 3.3.0 made the library unusable outright:

```
Declaration of Contributte\FormsBootstrap\Traits\BootstrapContainerTrait::addSubmit(string $name, $caption = null): SubmitButton
must be compatible with Nette\Forms\Container::addSubmit(string $name, Stringable|string|null $caption = null, ?Closure $onSubmit = null): SubmitButton
```

`Container::addSubmit()` gained a third `?Closure $onSubmit` argument in 3.3.0, so every `BootstrapForm` / `BootstrapContainer` was a fatal error at class-load time.

Beyond that, 3.3.0 pulls in `Nette\SmartObject` on `BaseControl`, `Container` and `Form`, and re-tags several magic properties as `@property-deprecated`. Two of them are ones this library read:

- `BaseControl::$caption` → `getCaption()` — read in `BootstrapRenderer::renderLabel()`, `CheckboxInput::getControl()`, `ButtonInput::getControl()`
- `Form::$renderer` → `getRenderer()` — read in `BootstrapRow::render()` and `BootstrapCell::render()`

Those emitted 14 distinct `E_USER_DEPRECATED` notices across 53 tests.

## Changes

- `composer.json`: `nette/forms` `3.2.9` → `3.3.0`, keeping the repo's exact-pin convention.
- `BootstrapContainerTrait::addSubmit()` takes `?Closure $onSubmit` and appends it to the button's `onClick`, matching what the parent does.
- The five deprecated magic-property reads become `getCaption()` / `getRenderer()` calls. Both getters have existed since well before 3.2.9, so this is not a 3.3-only construct.

Nothing else in the 3.2.9 → 3.3.0 diff touches what this library overrides. `Container::getControls()` changed its return type from `\Iterator` to `iterable`, but the renderer only ever `foreach`es over it; the `getValues(true)` and `getOption($key, $default)` deprecated forms that were removed are not used here.

## Tests

- `testAddSubmitTakesAnOnSubmitHandler` / `testAddSubmitWithoutHandlerRegistersNoClickListener` in `tests/Traits/BootstrapContainerTraitTest.php` cover the new argument.
- `testAddSubmitHandlerIsCalledWhenThatButtonSubmitsTheForm` in `tests/E2E/FormSubmissionTest.php` drives a whole request through a real presenter and asserts the handler actually fires with the submitted values.

`make tests` (158 tests, 242 assertions, no deprecations), `make phpstan` and `make cs` all pass.

Note for whoever merges: the same source also passes tests and PHPStan unchanged against 3.2.9, so widening the constraint to `^3.2.9` is available if supporting both lines is ever wanted — the exact pin here is deliberate, per the convention every previous bump followed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update: PHP 8.3 minimum + dependency bumps

`nette/forms` 3.3.0 — along with `nette/application` 3.3.0 and `nette/component-model` 4.0.1, which it pulls in — declares `php: 8.3 - 8.5`. PHP 8.2 therefore cannot be supported on this line at all, which is what the `--ignore-platform-reqs` CI job was papering over.

- `composer.json`: `php: ">=8.2"` → `">=8.3"`, and the exact `nette/forms` pin relaxed to `^3.3.0` so patch releases are picked up.
- `phpunit/phpunit` `^11.5` → `^12.5`. PHPUnit 12 requires `php >=8.3`, so this was blocked until now. `phpunit.xml` points at the 12.5 schema, and the `createMock(Presenter::class)` calls become `createStub(...)` — PHPUnit 12 emits a notice for a mock with no configured expectations, and these presenters are pure stand-in parents.
- CI: the 8.2 jobs are gone. qa, static analysis, coverage and `--prefer-lowest` all run on 8.3; the test matrix is 8.3 / 8.4 / 8.5. The `--ignore-platform-reqs` include is dropped.
- README version table: dev row `^0.9` now reads `^8.3`.

Everything else was already at its newest installable release — the remaining outdated transitives (`squizlabs/php_codesniffer` 4.x, `slevomat/coding-standard` 8.31) are held back by `contributte/qa` `^0.4`, whose only newer version is `0.5.x-dev`.

Verified on PHP 8.3.31: `make tests` (158 tests, 242 assertions), `make phpstan`, `make cs` all pass, and the `--prefer-lowest` resolution (forms 3.3.0 + application 3.2.0 + component-model 3.2.0) passes the suite too.

This is a breaking change for consumers on PHP 8.2 — intended for the next major.
