### PR TITLE
fix: take maxlength from $maxLength instead of $cols

### DIFF
--- a/src/Traits/BootstrapContainerTrait.php
+++ b/src/Traits/BootstrapContainerTrait.php
@@ -191,7 +191,7 @@ trait BootstrapContainerTrait
 		int $maxLength = 255
 	): NetteTextInput
 	{
-		return $this->addText($name, $label)
+		return $this->addText($name, $label, null, $maxLength)
 			->setNullable(BootstrapForm::$allwaysUseNullable)
 			->addRule(Form::Email);
 	}
@@ -313,21 +313,17 @@ trait BootstrapContainerTrait
 
 	/**
 	 * @param string|Html|null $label
-	 * @param int|null $cols ignored
-	 * @param int|null $maxLength ignored
+	 * @param int|null $cols width of the input, rendered as the cols attribute
+	 * @param int|null $maxLength maximum length of the value, rendered as the maxlength attribute
 	 * @return TextInput
 	 */
 	public function addText(string $name, $label = null, ?int $cols = null, ?int $maxLength = null): NetteTextInput
 	{
-		$comp = new TextInput($label);
+		$comp = new TextInput($label, $maxLength);
 		$comp->setNullable(BootstrapForm::$allwaysUseNullable);
 
 		if ($cols !== null) {
 			$comp->setHtmlAttribute('cols', $cols);
-		}
-
-		if ($maxLength !== null) {
-			$comp->setHtmlAttribute('maxlength', $cols);
 		}
 
 		$this->addComponent($comp, $name);
@@ -337,8 +333,8 @@ trait BootstrapContainerTrait
 
 	/**
 	 * @param string|Html|null $label
-	 * @param int|null $cols ignored
-	 * @param int|null $rows ignored
+	 * @param int|null $cols width of the textarea, rendered as the cols attribute
+	 * @param int|null $rows height of the textarea, rendered as the rows attribute
 	 * @return TextAreaInput
 	 */
 	public function addTextArea(string $name, $label = null, ?int $cols = null, ?int $rows = null): TextArea

--- a/tests/Traits/BootstrapContainerTraitTest.php
+++ b/tests/Traits/BootstrapContainerTraitTest.php
@@ -80,6 +80,54 @@ class BootstrapContainerTraitTest extends BaseTestCase
 		$this->assertStringContainsString('form-control', (string) $input->getControl());
 	}
 
+	/**
+	 * The maxlength attribute has to come from $maxLength, not from the
+	 * visual width in $cols. See issue #104.
+	 */
+	public function testAddTextTakesMaxLengthFromItsOwnArgument(): void
+	{
+		$form = new BootstrapForm();
+		$input = $form->addText('name', 'Name', 10, 50);
+
+		$html = (string) $input->getControl();
+		$this->assertStringContainsString('maxlength="50"', $html);
+		$this->assertStringContainsString('cols="10"', $html);
+	}
+
+	public function testAddTextRendersMaxLengthWithoutCols(): void
+	{
+		$form = new BootstrapForm();
+		$input = $form->addText('name', 'Name', null, 50);
+
+		$html = (string) $input->getControl();
+		$this->assertStringContainsString('maxlength="50"', $html);
+		$this->assertStringNotContainsString('cols=', $html);
+	}
+
+	public function testAddTextWithoutMaxLengthRendersNoMaxLength(): void
+	{
+		$form = new BootstrapForm();
+		$input = $form->addText('name', 'Name', 10);
+
+		$this->assertStringNotContainsString('maxlength', (string) $input->getControl());
+	}
+
+	public function testAddPasswordPassesMaxLengthOn(): void
+	{
+		$form = new BootstrapForm();
+		$input = $form->addPassword('secret', 'Secret', 10, 20);
+
+		$this->assertStringContainsString('maxlength="20"', (string) $input->getControl());
+	}
+
+	public function testAddEmailAppliesItsMaxLength(): void
+	{
+		$form = new BootstrapForm();
+
+		$this->assertStringContainsString('maxlength="255"', (string) $form->addEmail('a', 'A')->getControl());
+		$this->assertStringContainsString('maxlength="30"', (string) $form->addEmail('b', 'B', 30)->getControl());
+	}
+
 	public function testAddMultiUploadTakesSeveralFiles(): void
 	{
 		$form = new BootstrapForm();


### PR DESCRIPTION
Closes #104.

## The bug

`BootstrapContainerTrait::addText()` guarded on `$maxLength` but then wrote `$cols` into the attribute:

```php
if ($maxLength !== null) {
    $comp->setHtmlAttribute('maxlength', $cols);
}
```

So `addText('name', 'Name', 10, 50)` rendered `maxlength="10"` — the maximum length of the value was decided by the visual width of the input, and the `$maxLength` that was actually asked for never reached the HTML. Passing `$maxLength` without `$cols` rendered `maxlength=""`.

`addPassword()` delegates to `addText()`, so it carried the same bug.

## The fix

`$maxLength` now goes through the `TextInput` constructor, which is how `Nette\Forms\Container::addText()` applies it, and `$cols` keeps setting the `cols` attribute on its own.

## Also in here

**`addEmail()` never applied its `$maxLength`.** It takes `int $maxLength = 255` and then called `addText($name, $label)` with the label only, so the argument was silently dropped — same defect, same two lines of code. It now passes the value on.

This one is a visible output change: every field built with `addEmail()` starts rendering `maxlength="255"` (or whatever was passed) where it previously rendered no `maxlength` at all. That is what `Nette\Forms\Container::addEmail()` has always produced, and the alternative is leaving a documented parameter that does nothing — flagging it since it lands in rendered HTML for existing users, and this branch is aimed at the next major anyway.

The `@param int|null $cols ignored` / `$maxLength ignored` notes on `addText()` and `addTextArea()` described neither the old nor the new behaviour — both arguments have always been written to attributes — so they now say what the arguments do.

**Not changed:** `addText()` renders `$cols` as a `cols` attribute, while Nette renders it as `size` (`cols` is a `<textarea>` attribute, not an `<input>` one). That is a separate pre-existing divergence, it is not what #104 reports, and correcting it would silently rewrite the HTML of every field that passes `$cols` — worth its own issue if you want it aligned.

## Tests

Five tests in `tests/Traits/BootstrapContainerTraitTest.php` covering `maxlength` from `$maxLength` alongside `cols`, `$maxLength` without `$cols`, `$cols` alone rendering no `maxlength`, `addPassword()` passing it through, and `addEmail()` applying both its default and an explicit value. Four of the five fail on master.

`make tests` (163 tests, 250 assertions), `make phpstan` and `make cs` all pass. No rendering fixture under `tests/data/` changed — none of them build an email field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
