### PR TITLE
fix: export rules added after DateInput's format rule

### DIFF
--- a/src/Inputs/DateInput.php
+++ b/src/Inputs/DateInput.php
@@ -55,9 +55,25 @@ class DateInput extends TextInput
 
 		parent::__construct($label, null);
 
-		$this->addRule(fn (Control $input) => DateTimeFormat::validate($this->format, $input->getValue()), $this->invalidFormatMessage);
+		// must be a static callable, otherwise Nette::exportRules() stops at this rule
+		// and every rule/condition added later is missing in data-nette-rules
+		$this->addRule([self::class, 'validateFormat'], $this->invalidFormatMessage);
 
 		$this->setFormat(static::$defaultFormat);
+	}
+
+	/**
+	 * Checks that the value matches the control's format.
+	 *
+	 * Kept as a public static method (instead of a closure) so that the rule is exportable
+	 * and does not cut off the rules that follow it. The client side has no validator of
+	 * this name and simply skips it.
+	 */
+	public static function validateFormat(Control $input): bool
+	{
+		assert($input instanceof self);
+
+		return DateTimeFormat::validate($input->getFormat(), $input->getValue());
 	}
 
 	/**

--- a/tests/Inputs/DateInputTest.php
+++ b/tests/Inputs/DateInputTest.php
@@ -5,16 +5,20 @@ namespace Tests\Inputs;
 use Contributte\FormsBootstrap\BootstrapForm;
 use Contributte\FormsBootstrap\Enums\DateTimeFormat;
 use Contributte\FormsBootstrap\Inputs\DateInput;
+use Nette\Forms\Form;
 use Tests\BaseTestCase;
 
 class DateInputTest extends BaseTestCase
 {
 
+	// rule that DateInput adds in its constructor
+	private const FORMAT_RULE = '[{"op":"Contributte\\\\FormsBootstrap\\\\Inputs\\\\DateInput::validateFormat","msg":"invalid/incorrect format"}]';
+
 	public function testDefaultDate(): void
 	{
 		$form = new BootstrapForm();
 		$dt = $form->addBootstrapDate('date', 'Date');
-		$this->assertEquals('<input type="text" name="date" id="frm-date" class="form-control" placeholder="d.m.yyyy (31.12.1998)">', $dt->getControl()->render());
+		$this->assertEquals('<input type="text" name="date" id="frm-date" data-nette-rules=\'' . self::FORMAT_RULE . '\' class="form-control" placeholder="d.m.yyyy (31.12.1998)">', $dt->getControl()->render());
 	}
 
 	public function testWithCustomStaticFormat(): void
@@ -22,7 +26,26 @@ class DateInputTest extends BaseTestCase
 		$form = new BootstrapForm();
 		DateInput::$defaultFormat = DateTimeFormat::D_YMD_DASHES;
 		$dt = $form->addBootstrapDate('date', 'Date');
-		$this->assertEquals('<input type="text" name="date" id="frm-date" class="form-control" placeholder="yyyy-mm-dd (1998-12-31)">', $dt->getControl()->render());
+		$this->assertEquals('<input type="text" name="date" id="frm-date" data-nette-rules=\'' . self::FORMAT_RULE . '\' class="form-control" placeholder="yyyy-mm-dd (1998-12-31)">', $dt->getControl()->render());
+	}
+
+	/**
+	 * @see https://github.com/contributte/forms-bootstrap/issues/61
+	 */
+	public function testConditionsAreExported(): void
+	{
+		$form = new BootstrapForm();
+		$checkbox = $form->addCheckbox('agree', 'Agree');
+		$date = $form->addBootstrapDate('date', 'Date');
+		$date->addConditionOn($checkbox, Form::Equal, true)
+			->setRequired('Date is required');
+		$date->addCondition(Form::Filled)
+			->addRule(Form::MinLength, 'Too short', 3);
+
+		$rules = $date->getControl()->render();
+		$this->assertStringContainsString(':equal', $rules);
+		$this->assertStringContainsString(':filled', $rules);
+		$this->assertStringContainsString(':minLength', $rules);
 	}
 
 }

--- a/tests/Inputs/DateTimeInputTest.php
+++ b/tests/Inputs/DateTimeInputTest.php
@@ -11,11 +11,14 @@ use Tests\BaseTestCase;
 class DateTimeInputTest extends BaseTestCase
 {
 
+	// rule that DateInput adds in its constructor
+	private const FORMAT_RULE = '[{"op":"Contributte\\\\FormsBootstrap\\\\Inputs\\\\DateInput::validateFormat","msg":"invalid/incorrect format"}]';
+
 	public function testDefaultDateTime(): void
 	{
 		$form = new BootstrapForm();
 		$dt = $form->addBootstrapDateTime('datetime', 'Date and time');
-		$this->assertEquals('<input type="text" name="datetime" id="frm-datetime" class="form-control" placeholder="d.m.yyyy h:mm (31.12.1998 23:59)">', $dt->getControl()->render());
+		$this->assertEquals('<input type="text" name="datetime" id="frm-datetime" data-nette-rules=\'' . self::FORMAT_RULE . '\' class="form-control" placeholder="d.m.yyyy h:mm (31.12.1998 23:59)">', $dt->getControl()->render());
 	}
 
 	public function testDefaultAdditionalClasses(): void
@@ -24,7 +27,7 @@ class DateTimeInputTest extends BaseTestCase
 		DateTimeInput::$additionalHtmlClasses[] = 'datetimepicker';
 		DateTimeInput::$additionalHtmlClasses[] = 'cool';
 		$dt = $form->addBootstrapDateTime('datetime', 'Date and time');
-		$this->assertEquals('<input type="text" name="datetime" id="frm-datetime" class="form-control datetimepicker cool" placeholder="d.m.yyyy h:mm (31.12.1998 23:59)">', $dt->getControl()->render());
+		$this->assertEquals('<input type="text" name="datetime" id="frm-datetime" data-nette-rules=\'' . self::FORMAT_RULE . '\' class="form-control datetimepicker cool" placeholder="d.m.yyyy h:mm (31.12.1998 23:59)">', $dt->getControl()->render());
 	}
 
 	public function testNotMessingHtmlClassOfDateAndDateTime(): void
@@ -60,6 +63,29 @@ class DateTimeInputTest extends BaseTestCase
 		$form->setSubmittedBy($submit);
 		$form->validate();
 		$this->assertEquals(new DateTime('2020-05-01'), $dt->getValue());
+	}
+
+	public function testValidationWithIncorrectFormat(): void
+	{
+		$form = new BootstrapForm();
+		$dt = $form->addBootstrapDateTime('datetime', 'Date and time');
+		$dt->setValue('not a date at all');
+		$submit = $form->addSubmit('send');
+		$form->setSubmittedBy($submit);
+		$form->validate();
+		$this->assertFalse($form->isValid());
+		$this->assertSame([$dt->invalidFormatMessage], $dt->getErrors());
+	}
+
+	public function testEmptyOptionalValueDoesNotFailValidation(): void
+	{
+		$form = new BootstrapForm();
+		$dt = $form->addBootstrapDateTime('datetime', 'Date and time');
+		$submit = $form->addSubmit('send');
+		$form->setSubmittedBy($submit);
+		$form->validate();
+		$this->assertTrue($form->isValid());
+		$this->assertSame([], $dt->getErrors());
 	}
 
 }


### PR DESCRIPTION
Closes #61.

## The bug

`addCondition()` / `addConditionOn()` on `DateInput` and `DateTimeInput` never reached `data-nette-rules`, so client-side validation ignored them. Only `setRequired()` worked.

`DateInput::__construct()` registered its format check as a closure:

```php
$this->addRule(fn (Control $input) => DateTimeFormat::validate($this->format, $input->getValue()), $this->invalidFormatMessage);
```

`Helpers::exportRules()` **`break`s** — not `continue`s — on the first rule whose `canExport()` is false, and `Rule::canExport()` accepts only strings and static callables, never closures. Since the format rule is added in the constructor it sits in front of everything, so every rule and condition registered afterwards was silently dropped from the exported payload.

`setRequired()` was unaffected because `Rules::addRule()` puts the required rule in a separate `$required` slot rather than the ordered list, so it never sat behind the closure — which is exactly the symptom reported in the issue.

## The fix

The format check becomes a public static method, making the rule exportable so it no longer truncates what follows.

Server-side validation is unchanged — same format, same value, same message.

Client-side, the rule now appears in `data-nette-rules` as `Contributte\FormsBootstrap\Inputs\DateInput::validateFormat`. `netteForms.js` has no validator under that name: `validateRule()` returns `null` for unknown validators and `validateControl()` `continue`s past a `null`, so the browser skips it and goes on to evaluate the user's conditions.

### Trade-off worth a reviewer's eye

This adds a `data-nette-rules` attribute to every date input for a rule no client-side validator implements. The alternative — dropping the Nette rule and calling `addError()` from `validate()` — keeps the markup clean but means re-implementing Nette's empty-optional skipping and condition-branch nesting by hand. I went with the smaller change; happy to switch if you'd rather not emit the attribute.

## Tests

| Test | Guards | Verified by |
|---|---|---|
| `testConditionsAreExported` | the issue itself — conditions reach `data-nette-rules` | fails against pre-fix source |
| `testValidationWithIncorrectFormat` | server-side rejection survives the swap | fails when `validateFormat` is stubbed to `return true` |
| `testEmptyOptionalValueDoesNotFailValidation` | an empty optional date doesn't trip the format rule | passes |

The middle one closed a real gap: the two pre-existing validation tests only feed *valid* dates and assert `getValue()`, so a broken validator would not have turned the suite red. Both new guards were mutation-checked rather than just observed green.

Four existing assertions were updated for the now-present `data-nette-rules` attribute.

`make qa` (PHPStan level 7 + codesniffer) and the full suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)