### PR TITLE
fix: make {formPrint} work with BootstrapRenderer

### DIFF
--- a/src/BootstrapRenderer.php
+++ b/src/BootstrapRenderer.php
@@ -626,7 +626,7 @@ class BootstrapRenderer implements FormRenderer
 	 */
 	protected function shouldShowValidation(): bool
 	{
-		return $this->form instanceof BootstrapForm && $this->form->showValidation;
+		return $this->form instanceof BootstrapForm && $this->form->isShowValidation();
 	}
 
 	/**

--- a/src/BootstrapRenderer.php
+++ b/src/BootstrapRenderer.php
@@ -14,6 +14,7 @@ use Nette\Forms\Controls\BaseControl;
 use Nette\Forms\Form;
 use Nette\Forms\FormRenderer;
 use Nette\Utils\Html;
+use SplObjectStorage;
 
 /**
  * Converts a Form into Bootstrap 4 HTML output.
@@ -61,9 +62,21 @@ class BootstrapRenderer implements FormRenderer
 	/** @var bool */
 	private $groupHidden = true;
 
+	/**
+	 * What this renderer has already drawn in the current render.
+	 *
+	 * Tracked by identity rather than only through RendererOptions::_RENDERED, because the
+	 * dummy controls Nette\Forms\Blueprint feeds us forward getOption() to the control they
+	 * wrap, so an option written here would be read back off a different object.
+	 *
+	 * @var SplObjectStorage<BaseControl|BootstrapRow, null>
+	 */
+	private $renderedControls;
+
 	public function __construct(int $mode = RenderMode::VERTICAL_MODE)
 	{
 		$this->setMode($mode);
+		$this->renderedControls = new SplObjectStorage();
 	}
 
 	/**
@@ -330,6 +343,8 @@ class BootstrapRenderer implements FormRenderer
 	 */
 	public function renderBegin(): string
 	{
+		$this->renderedControls = new SplObjectStorage();
+
 		foreach ($this->form->getControls() as $control) {
 			if ($control instanceof BaseControl || $control instanceof BootstrapRow) {
 				$control->setOption(RendererOptions::_RENDERED, false);
@@ -440,7 +455,7 @@ class BootstrapRenderer implements FormRenderer
 	public function renderControl(BaseControl $control): string
 	{
 		$controlHtml = $control->getControl();
-		$control->setOption(RendererOptions::_RENDERED, true);
+		$this->markRendered($control);
 
 		// Blueprint's dummy controls return a bare '{input ...}' placeholder, which has
 		// no attributes to configure — pass it through untouched
@@ -477,7 +492,7 @@ class BootstrapRenderer implements FormRenderer
 				continue;
 			}
 
-			if ($control->getOption(RendererOptions::_RENDERED)) {
+			if ($this->isRendered($control)) {
 				continue;
 			}
 
@@ -617,6 +632,30 @@ class BootstrapRenderer implements FormRenderer
 	public function setMode(int $renderMode): void
 	{
 		$this->renderMode = $renderMode;
+	}
+
+	/**
+	 * Records that this renderer has drawn the control, both for itself and, as before,
+	 * as an option other code may read.
+	 *
+	 * @param BaseControl|BootstrapRow $control
+	 */
+	protected function markRendered($control): void
+	{
+		$this->renderedControls->attach($control);
+		$control->setOption(RendererOptions::_RENDERED, true);
+	}
+
+	/**
+	 * Whether the control should be skipped: either this renderer has already drawn it,
+	 * or somebody marked it as rendered by hand.
+	 *
+	 * @param BaseControl|BootstrapRow $control
+	 */
+	protected function isRendered($control): bool
+	{
+		return $this->renderedControls->contains($control)
+			|| (bool) $control->getOption(RendererOptions::_RENDERED);
 	}
 
 	/**
@@ -770,6 +809,15 @@ class BootstrapRenderer implements FormRenderer
 		} else {
 			throw new Nette\NotImplementedException('renderer is unable to render feedback for ' . gettype($control));
 		}
+	}
+
+	/**
+	 * Blueprint renders through a clone of the form's renderer; it must not inherit
+	 * bookkeeping from the render the original may be in the middle of.
+	 */
+	public function __clone()
+	{
+		$this->renderedControls = new SplObjectStorage();
 	}
 
 }

--- a/src/BootstrapRenderer.php
+++ b/src/BootstrapRenderer.php
@@ -41,7 +41,12 @@ class BootstrapRenderer implements FormRenderer
 	 */
 	protected $gridBreakPoint = 'sm';
 
-	/** @var BootstrapForm */
+	/**
+	 * Not necessarily a BootstrapForm: Nette\Forms\Blueprint (the {formPrint} macro) renders
+	 * a plain dummy form through a clone of this renderer.
+	 *
+	 * @var Form
+	 */
 	protected $form;
 
 	/** @var int */
@@ -65,7 +70,7 @@ class BootstrapRenderer implements FormRenderer
 	 * Sets the form for which to render. Used only if a specific function of the renderer must be executed
 	 * outside of render(), such as during assisted manual rendering.
 	 */
-	public function attachForm(BootstrapForm $form): void
+	public function attachForm(Form $form): void
 	{
 		$this->form = $form;
 	}
@@ -306,8 +311,6 @@ class BootstrapRenderer implements FormRenderer
 
 	/**
 	 * Provides complete form rendering.
-	 *
-	 * @param BootstrapForm $form
 	 */
 	public function render(Form $form): string
 	{
@@ -436,10 +439,16 @@ class BootstrapRenderer implements FormRenderer
 	 */
 	public function renderControl(BaseControl $control): string
 	{
-		/** @var Html $controlHtml */
 		$controlHtml = $control->getControl();
 		$control->setOption(RendererOptions::_RENDERED, true);
-		if (($this->form->showValidation || $control->hasErrors()) && $control instanceof IValidationInput) {
+
+		// Blueprint's dummy controls return a bare '{input ...}' placeholder, which has
+		// no attributes to configure — pass it through untouched
+		if (!$controlHtml instanceof Html) {
+			return (string) $controlHtml;
+		}
+
+		if (($this->shouldShowValidation() || $control->hasErrors()) && $control instanceof IValidationInput) {
 			$controlHtml = $control->showValidation($controlHtml);
 		}
 
@@ -509,11 +518,17 @@ class BootstrapRenderer implements FormRenderer
 	 */
 	public function renderLabel(BaseControl $control): Html
 	{
+		$controlLabel = $control->getLabel();
+
+		// Blueprint's dummy controls carry no caption but do return a '{label ...}' placeholder,
+		// which already expands to a whole <label> — emit it raw instead of nesting it in ours
+		if (is_string($controlLabel) && $controlLabel !== '') {
+			return Html::el()->setHtml($controlLabel);
+		}
+
 		if ($control->getCaption() === null) {
 			return Html::el();
 		}
-
-		$controlLabel = $control->getLabel();
 
 		if ($controlLabel instanceof Html && $controlLabel->getName() === 'label') {
 			// the control has already provided us with the element, no need to create our own
@@ -605,6 +620,16 @@ class BootstrapRenderer implements FormRenderer
 	}
 
 	/**
+	 * Whether valid controls should be explicitly marked as valid.
+	 *
+	 * Only a BootstrapForm knows about this, and the attached form is not always one.
+	 */
+	protected function shouldShowValidation(): bool
+	{
+		return $this->form instanceof BootstrapForm && $this->form->showValidation;
+	}
+
+	/**
 	 * Fetch config tailored for current render mode
 	 *
 	 * @param string $key first-level key of $this->config
@@ -680,7 +705,7 @@ class BootstrapRenderer implements FormRenderer
 				$isValid = false;
 				$showFeedback = true;
 				$messages = $control->getErrors();
-			} elseif ($this->form->showValidation) {
+			} elseif ($this->shouldShowValidation()) {
 				$isValid = true;
 				// control is valid and we want to explicitly show that it's valid
 				$message = $control->getOption(RendererOptions::FEEDBACK_VALID);

--- a/src/Enums/RendererOptions.php
+++ b/src/Enums/RendererOptions.php
@@ -12,11 +12,11 @@ class RendererOptions
 	/**
 	 * Internal. If control has already been rendered.
 	 *
-	 * Deliberately the same key Nette itself uses (BaseControl::getControl() sets it, and
-	 * Nette\Forms\Blueprint special-cases it), so that {formPrint} does not render every
-	 * grouped control twice.
+	 * Deliberately NOT Nette's own 'rendered' key, which BaseControl::getControl() sets on
+	 * every fetch: the renderer must be able to tell "I drew this" apart from "somebody
+	 * asked for the html", or assisted manual rendering silently skips controls.
 	 */
-	public const _RENDERED = 'rendered';
+	public const _RENDERED = '_rendered';
 
 	/**
 	 * Boolean. Can se set on groups, if false, group will not be rendered separately.

--- a/src/Enums/RendererOptions.php
+++ b/src/Enums/RendererOptions.php
@@ -11,8 +11,12 @@ class RendererOptions
 
 	/**
 	 * Internal. If control has already been rendered.
+	 *
+	 * Deliberately the same key Nette itself uses (BaseControl::getControl() sets it, and
+	 * Nette\Forms\Blueprint special-cases it), so that {formPrint} does not render every
+	 * grouped control twice.
 	 */
-	public const _RENDERED = '_rendered';
+	public const _RENDERED = 'rendered';
 
 	/**
 	 * Boolean. Can se set on groups, if false, group will not be rendered separately.

--- a/src/Grid/BootstrapRow.php
+++ b/src/Grid/BootstrapRow.php
@@ -201,7 +201,7 @@ class BootstrapRow implements IComponent, Control
 	 */
 	public function getOption(string $option)
 	{
-		return $this->options[$option];
+		return $this->options[$option] ?? null;
 	}
 
 	/**

--- a/src/Traits/FakeControlTrait.php
+++ b/src/Traits/FakeControlTrait.php
@@ -2,8 +2,11 @@
 
 namespace Contributte\FormsBootstrap\Traits;
 
+use Nette\ComponentModel\Component;
+use Nette\ComponentModel\IComponent;
 use Nette\Forms\Control;
 use Nette\NotImplementedException;
+use Stringable;
 
 /**
  * Trait FakeControlTrait.
@@ -43,6 +46,45 @@ trait FakeControlTrait
 	public function isOmitted(): bool
 	{
 		return true;
+	}
+
+	/**
+	 * Hierarchical name of the component, the way a real Nette component would report it.
+	 *
+	 * Needed because tools that walk $form->getControls() -- Nette\Forms\Blueprint, i.e. the
+	 * {formPrint} macro -- call this on everything they find, and a fake control is found too.
+	 *
+	 * @param class-string<IComponent>|null $type
+	 */
+	public function lookupPath(?string $type = null, bool $throw = true): ?string
+	{
+		$parent = $this->getParent();
+
+		// the searched-for ancestor is our direct parent, so the path is just our own name
+		if ($type !== null && $parent instanceof $type) {
+			return $this->getName();
+		}
+
+		$parentPath = $parent instanceof Component ? $parent->lookupPath($type, $throw) : null;
+
+		return ($parentPath === null || $parentPath === '' ? '' : $parentPath . IComponent::NameSeparator)
+			. $this->getName();
+	}
+
+	/**
+	 * A fake control has no label.
+	 *
+	 * @param string|Stringable|null $caption
+	 * @return null
+	 */
+	public function getLabel($caption = null)
+	{
+		return null;
+	}
+
+	public function isRequired(): bool
+	{
+		return false;
 	}
 
 	/**

--- a/tests/Grid/BootstrapRowTest.php
+++ b/tests/Grid/BootstrapRowTest.php
@@ -2,10 +2,12 @@
 
 namespace Tests\Grid;
 
+use ArrayObject;
 use Contributte\FormsBootstrap\BootstrapForm;
 use Contributte\FormsBootstrap\Grid\BootstrapCell;
 use Contributte\FormsBootstrap\Grid\BootstrapRow;
 use Nette\Application\UI\Presenter;
+use Nette\Forms\Form;
 use Nette\NotImplementedException;
 use Tests\BaseTestCase;
 
@@ -111,6 +113,71 @@ class BootstrapRowTest extends BaseTestCase
 		$this->row->addCell(12)->addText('name', 'Name');
 
 		$this->assertSame('name', $this->form['name']->getName());
+	}
+
+	public function testRowHasNoLabelAndIsNeverRequired(): void
+	{
+		$this->assertNull($this->row->getLabel());
+		$this->assertNull($this->row->getLabel('caption'));
+		$this->assertFalse($this->row->isRequired());
+	}
+
+	public function testOptionsRoundTrip(): void
+	{
+		$this->row->setOption('description', 'Hello');
+
+		$this->assertSame('Hello', $this->row->getOption('description'));
+	}
+
+	public function testUnsetOptionIsNullAndDoesNotWarn(): void
+	{
+		$warnings = new ArrayObject();
+		set_error_handler(
+			static function (int $severity, string $message) use ($warnings): bool {
+				$warnings[] = $message;
+
+				return true;
+			},
+			E_WARNING,
+		);
+
+		try {
+			$value = $this->row->getOption('never-set');
+		} finally {
+			restore_error_handler();
+		}
+
+		$this->assertNull($value);
+		$this->assertSame([], $warnings->getArrayCopy());
+	}
+
+	public function testLookupPathOfRowDirectlyOnForm(): void
+	{
+		$this->assertSame($this->row->getName(), $this->row->lookupPath(Form::class));
+	}
+
+	public function testLookupPathOfRowInsideContainer(): void
+	{
+		$container = $this->form->addContainer('sub');
+		$nested = $container->addRow();
+
+		$this->assertSame('sub-' . $nested->getName(), $nested->lookupPath(Form::class));
+	}
+
+	/**
+	 * The fake control must report its path exactly like a real sibling would,
+	 * whatever the form happens to be attached to.
+	 */
+	public function testLookupPathMatchesRealControlInSamePlace(): void
+	{
+		$container = $this->form->addContainer('sub');
+		$nested = $container->addRow();
+		$real = $container->addText('x');
+
+		$expected = static fn (string $path): string => substr($path, 0, -strlen('x')) . $nested->getName();
+
+		$this->assertSame($expected($real->lookupPath(Form::class)), $nested->lookupPath(Form::class));
+		$this->assertSame($expected((string) $real->lookupPath()), $nested->lookupPath());
 	}
 
 	protected function setUp(): void

--- a/tests/Rendering/BlueprintTest.php
+++ b/tests/Rendering/BlueprintTest.php
@@ -1,0 +1,113 @@
+<?php declare (strict_types = 1);
+
+namespace Tests\Rendering;
+
+use Contributte\FormsBootstrap\BootstrapForm;
+use Contributte\FormsBootstrap\Enums\RenderMode;
+use Nette\Forms\Blueprint;
+use Tests\BaseTestCase;
+
+/**
+ * Nette\Forms\Blueprint is what the {formPrint} Latte macro runs on. It renders a dummy
+ * plain Nette form through a clone of the form's own renderer.
+ *
+ * @see https://github.com/contributte/forms-bootstrap/issues/63
+ */
+class BlueprintTest extends BaseTestCase
+{
+
+	public function testGeneratesLatteForPlainForm(): void
+	{
+		$form = new BootstrapForm();
+		$form->addText('name', 'Name');
+		$form->addSubmit('send', 'Send');
+
+		$latte = (new Blueprint())->generateLatte($form);
+
+		$this->assertStringContainsString('{label name/}', $latte);
+		$this->assertStringContainsString('{input name}', $latte);
+		$this->assertStringContainsString('{input send}', $latte);
+		$this->assertStringContainsString('{inputError name}', $latte);
+	}
+
+	public function testKeepsBootstrapMarkupAroundPlaceholders(): void
+	{
+		$form = new BootstrapForm();
+		$form->setRenderMode(RenderMode::SIDE_BY_SIDE_MODE);
+		$form->addText('name', 'Name');
+
+		$latte = (new Blueprint())->generateLatte($form);
+
+		// the point of a bootstrap blueprint: the wrappers are the ones this renderer emits
+		$this->assertStringContainsString('class="form-group row"', $latte);
+		$this->assertStringContainsString('class="col-sm-9"', $latte);
+	}
+
+	public function testLabelPlaceholderIsNotNestedInAnotherLabel(): void
+	{
+		$form = new BootstrapForm();
+		$form->addText('name', 'Name');
+
+		$latte = (new Blueprint())->generateLatte($form);
+
+		// {label name/} expands to a whole <label>, so it must not sit inside one
+		$this->assertStringNotContainsString('<label', $latte);
+	}
+
+	public function testGroupedControlsAreRenderedOnce(): void
+	{
+		$form = new BootstrapForm();
+		$form->addGroup('Personal');
+		$form->addText('name', 'Name');
+		$form->addGroup('Other');
+		$form->addSelect('color', 'Color', ['r' => 'Red']);
+
+		$latte = (new Blueprint())->generateLatte($form);
+
+		$this->assertSame(1, substr_count($latte, '{input name}'));
+		$this->assertSame(1, substr_count($latte, '{input color}'));
+		$this->assertStringContainsString('<legend>Personal</legend>', $latte);
+		$this->assertStringContainsString('<legend>Other</legend>', $latte);
+	}
+
+	public function testHandlesContainersAndHiddenFields(): void
+	{
+		$form = new BootstrapForm();
+		$form->addHidden('token', 'x');
+		$form->addContainer('sub')->addText('nested', 'Nested');
+
+		$latte = (new Blueprint())->generateLatte($form);
+
+		$this->assertStringContainsString('{input sub-nested}', $latte);
+		$this->assertStringContainsString('{input token}', $latte);
+	}
+
+	/**
+	 * A BootstrapRow is a fake control, but Blueprint still walks it like any other.
+	 */
+	public function testHandlesGridRowsWithoutFailing(): void
+	{
+		$form = new BootstrapForm();
+		$row = $form->addRow();
+		$row->addCell(6)->addText('first', 'First');
+		$row->addCell(6)->addText('last', 'Last');
+
+		$latte = (new Blueprint())->generateLatte($form);
+
+		$this->assertStringContainsString('{input first}', $latte);
+		$this->assertStringContainsString('{input last}', $latte);
+	}
+
+	public function testGeneratesDataClass(): void
+	{
+		$form = new BootstrapForm();
+		$form->addText('name', 'Name');
+		$form->addCheckbox('agree', 'Agree');
+
+		$dataClass = (new Blueprint())->generateDataClass($form);
+
+		$this->assertStringContainsString('public string $name', $dataClass);
+		$this->assertStringContainsString('public bool $agree', $dataClass);
+	}
+
+}

--- a/tests/Rendering/BlueprintTest.php
+++ b/tests/Rendering/BlueprintTest.php
@@ -3,8 +3,11 @@
 namespace Tests\Rendering;
 
 use Contributte\FormsBootstrap\BootstrapForm;
+use Contributte\FormsBootstrap\BootstrapRenderer;
+use Contributte\FormsBootstrap\Enums\BootstrapVersion;
 use Contributte\FormsBootstrap\Enums\RenderMode;
 use Nette\Forms\Blueprint;
+use Nette\Forms\Form;
 use Tests\BaseTestCase;
 
 /**
@@ -96,6 +99,62 @@ class BlueprintTest extends BaseTestCase
 
 		$this->assertStringContainsString('{input first}', $latte);
 		$this->assertStringContainsString('{input last}', $latte);
+	}
+
+	public function testBootstrap5Blueprint(): void
+	{
+		BootstrapForm::switchBootstrapVersion(BootstrapVersion::V5);
+
+		try {
+			$form = new BootstrapForm();
+			$form->setRenderMode(RenderMode::SIDE_BY_SIDE_MODE);
+			$form->addText('name', 'Name');
+
+			$latte = (new Blueprint())->generateLatte($form);
+
+			$this->assertStringContainsString('{input name}', $latte);
+			// the v5 wrapper, not v4's form-group/form-row
+			$this->assertStringContainsString('class="mb-3 row"', $latte);
+			$this->assertStringNotContainsString('form-group', $latte);
+		} finally {
+			BootstrapForm::switchBootstrapVersion(BootstrapVersion::V4);
+		}
+	}
+
+	/**
+	 * Blueprint hands the renderer a plain form; this is that capability on its own.
+	 */
+	public function testRendererDrawsPlainNetteForm(): void
+	{
+		$form = new Form();
+		$form->addText('field', 'Field');
+
+		$html = (new BootstrapRenderer())->render($form);
+
+		$this->assertStringContainsString('name="field"', $html);
+		$this->assertStringContainsString('class="form-group"', $html);
+	}
+
+	public function testClonedRendererDrawsPlainNetteForm(): void
+	{
+		$bootstrapForm = new BootstrapForm();
+		$bootstrapForm->addText('field', 'Field');
+
+		$form = new Form();
+		$form->addText('field', 'Field');
+		$form->setRenderer(clone $bootstrapForm->getRenderer());
+
+		ob_start();
+
+		try {
+			$form->render();
+			$html = (string) ob_get_contents();
+		} finally {
+			ob_end_clean();
+		}
+
+		$this->assertStringContainsString('name="field"', $html);
+		$this->assertStringContainsString('class="form-group"', $html);
 	}
 
 	public function testGeneratesDataClass(): void

--- a/tests/Rendering/RenderedOptionTest.php
+++ b/tests/Rendering/RenderedOptionTest.php
@@ -8,8 +8,9 @@ use Nette\Application\UI\Presenter;
 use Tests\BaseTestCase;
 
 /**
- * The renderer marks controls it has drawn with RendererOptions::_RENDERED, which is the
- * same option key Nette itself sets from BaseControl::getControl(). These guard the overlap.
+ * The renderer tracks what it has already drawn, so that a control belonging to a group is
+ * not drawn again by the trailing pass. It must not confuse that with Nette's own 'rendered'
+ * option, which BaseControl::getControl() sets on every fetch.
  */
 class RenderedOptionTest extends BaseTestCase
 {
@@ -28,10 +29,48 @@ class RenderedOptionTest extends BaseTestCase
 	{
 		$this->form->addText('a', 'b');
 
-		// Nette sets the 'rendered' option as a side effect of this
+		// Nette sets its own 'rendered' option as a side effect of this
 		$this->form->getComponent('a')->getControl();
 
 		$this->assertStringContainsString('name="a"', $this->form->__toString(true));
+	}
+
+	/**
+	 * Assisted manual rendering: renderControls() called on its own, with no render() ahead
+	 * of it to reset anything. Fetching a control's html must not make it disappear.
+	 */
+	public function testAssistedRenderingIsNotDisturbedByFetchingControlHtml(): void
+	{
+		$this->form->addText('a', 'b');
+		$this->form->addText('c', 'd');
+
+		$renderer = $this->form->getRenderer();
+		$renderer->attachForm($this->form);
+
+		$this->form->getComponent('a')->getControl();
+
+		$html = $renderer->renderControls($this->form);
+
+		$this->assertStringContainsString('name="a"', $html);
+		$this->assertStringContainsString('name="c"', $html);
+	}
+
+	/**
+	 * The escape hatch of marking a control rendered by hand still works.
+	 */
+	public function testControlMarkedRenderedByHandIsSkipped(): void
+	{
+		$this->form->addText('a', 'b');
+		$this->form->addText('c', 'd');
+
+		$renderer = $this->form->getRenderer();
+		$renderer->attachForm($this->form);
+		$this->form->getComponent('a')->setOption(RendererOptions::_RENDERED, true);
+
+		$html = $renderer->renderControls($this->form);
+
+		$this->assertStringNotContainsString('name="a"', $html);
+		$this->assertStringContainsString('name="c"', $html);
 	}
 
 	public function testRenderingTwiceProducesTheSameOutput(): void

--- a/tests/Rendering/RenderedOptionTest.php
+++ b/tests/Rendering/RenderedOptionTest.php
@@ -1,0 +1,57 @@
+<?php declare (strict_types = 1);
+
+namespace Tests\Rendering;
+
+use Contributte\FormsBootstrap\BootstrapForm;
+use Contributte\FormsBootstrap\Enums\RendererOptions;
+use Nette\Application\UI\Presenter;
+use Tests\BaseTestCase;
+
+/**
+ * The renderer marks controls it has drawn with RendererOptions::_RENDERED, which is the
+ * same option key Nette itself sets from BaseControl::getControl(). These guard the overlap.
+ */
+class RenderedOptionTest extends BaseTestCase
+{
+
+	/** @var BootstrapForm */
+	private $form;
+
+	public function setUp(): void
+	{
+		$this->form = new BootstrapForm();
+		$this->form->setParent($this->createStub(Presenter::class));
+		$this->form->setAction('/');
+	}
+
+	public function testControlIsStillRenderedAfterItsControlHtmlWasFetched(): void
+	{
+		$this->form->addText('a', 'b');
+
+		// Nette sets the 'rendered' option as a side effect of this
+		$this->form->getComponent('a')->getControl();
+
+		$this->assertStringContainsString('name="a"', $this->form->__toString(true));
+	}
+
+	public function testRenderingTwiceProducesTheSameOutput(): void
+	{
+		$this->form->addGroup('Group');
+		$this->form->addText('a', 'b');
+		$this->form->addSubmit('send', 'Send');
+
+		$this->assertSame($this->form->__toString(true), $this->form->__toString(true));
+	}
+
+	public function testGroupedControlIsNotRenderedTwice(): void
+	{
+		$this->form->addGroup('Group');
+		$this->form->addText('a', 'b');
+
+		$html = $this->form->__toString(true);
+
+		$this->assertSame(1, substr_count($html, 'name="a"'));
+		$this->assertTrue($this->form->getComponent('a')->getOption(RendererOptions::_RENDERED));
+	}
+
+}


### PR DESCRIPTION
Closes #63.

> **Overlaps #111.** @f3l1x already opened [#111](https://github.com/contributte/forms-bootstrap/pull/111) against this issue, and it independently reaches the same conclusion on the first three points below. This PR is a superset — it also fixes the group duplication and the grid crash, which #111 does not touch — so I'd suggest landing this one and closing #111, or cherry-picking whichever half you prefer. Its plain-form, cloned-renderer and Bootstrap 5 test scenarios are adapted here with credit.

The reported exception (`Runtime::renderformPrint()`) was from the Latte 2 era and no longer occurs, but the feature is still broken on current master — it just fails later and differently. `Nette\Forms\Blueprint`, which backs `{formPrint}`, renders a **dummy plain Nette form** through a **clone of the real form's renderer**, and `BootstrapRenderer` assumes both the form and its controls are ours.

Reproduced before touching anything (`Blueprint::generateLatte()` is public, so no Latte install needed):

```
TypeError: BootstrapRenderer::attachForm(): Argument #1 ($form) must be of type
BootstrapForm, Nette\Forms\Form@anonymous given
```

## What was wrong

| | Symptom | Also in #111 |
|---|---|---|
| `attachForm()` required a `BootstrapForm` | TypeError — nothing rendered at all | yes |
| `renderControl()` assumed `getControl()` returns `Html` | TypeError — the dummy returns a bare `{input …}` string | yes |
| `renderLabel()` returns early when `getCaption()` is null | every `{label …}` silently missing from the blueprint | yes |
| grouped controls tracked via an option the dummy forwards elsewhere | every grouped control emitted **twice** | no |
| `BootstrapRow` has no `lookupPath()` | MemberAccessException on any form using `addRow()` | no |

The duplication is the interesting one. Blueprint's dummy controls forward `getOption()` to the control they wrap, so the renderer's `_rendered` mark was written to the dummy and read back off a different object — always false, so every grouped control was drawn again by the trailing pass. The renderer now remembers what it drew in an `SplObjectStorage`, which is identity-based and immune to that forwarding.

## What changed

- `attachForm(Form $form)`; the single `BootstrapForm`-only access (`showValidation`) now goes through `shouldShowValidation()`, which calls the real getter rather than the magic property.
- Non-`Html` control output is passed through untouched — there are no attributes to configure on a placeholder.
- A string label is emitted raw via `Html::el()`, not nested — `{label name/}` already expands to a whole `<label>`. This keeps `renderLabel(): Html` intact; #111 widens the signature to `Html|string` instead, which works equally well but changes the public return type.
- Rendered-control bookkeeping moved into the renderer (`markRendered()` / `isRendered()`), with `__clone()` giving a cloned renderer its own. `RendererOptions::_RENDERED` is **unchanged** — it is still written, and still honoured if you set it by hand.
- `lookupPath()` / `getLabel()` / `isRequired()` added to `FakeControlTrait`.
- Drive-by: `BootstrapRow::getOption()` warned on unset options instead of returning null as its own docblock promises. Reached through this same path.

## Risk to existing behaviour

I probed this directly rather than reasoning about it. One earlier revision of this branch reused Nette's own `'rendered'` option key to fix the duplication, which turned out to break assisted manual rendering: `BaseControl::getControl()` sets that key on every fetch, so `renderControls()` called without a preceding `render()` silently skipped any control whose html had been fetched. That is why the bookkeeping is identity-based now, and `RenderedOptionTest::testAssistedRenderingIsNotDisturbedByFetchingControlHtml` fails if anyone tries the shortcut again.

What remains, and is unavoidable for this fix: **a subclass overriding `attachForm(BootstrapForm $form)` becomes a fatal error** at class-declaration time, since a child may not narrow a parameter type. #111 has the same break. Anything that only *calls* `attachForm()` is fine.

`renderLabel()` now calls `getLabel()` before the caption check, so a control with no caption gets `getLabel()` called where it previously did not. Nette's own controls have no side effects there, and all 66 snapshot fixtures are byte-identical.

## Result

```latte
<form n:name="myForm"><fieldset><legend>Personal</legend>
<div class="form-group row">
	{label name/}
	<div class="col-sm-9">{input name}
		<div class="invalid-feedback">{inputError name}<br></div>
	</div>
</div>
</fieldset></form>
```

## Tests

**`tests/Rendering/BlueprintTest.php`** — plain forms, side-by-side wrappers, label nesting, group de-duplication, containers + hidden fields, grid rows, Bootstrap 5, and the renderer drawing a plain `Nette\Forms\Form` both directly and through a clone.

**`tests/Rendering/RenderedOptionTest.php`** — the bookkeeping: a control whose `getControl()` was called still renders (both under full render and under assisted manual rendering), rendering twice is idempotent, a grouped control appears once, and marking a control rendered by hand still skips it.

**`tests/Grid/BootstrapRowTest.php`** — extended with the fake-control surface: `lookupPath()` (asserting a fake control reports the same path a real sibling would), `getLabel()`, `isRequired()`, and `getOption()` returning null for an unset key without raising a warning.

Verified against `origin/master`'s source rather than assumed: 6 of the new tests error there. `make qa` (PHPStan level 7 + codesniffer) and the full suite pass: 179 tests, 284 assertions.

## Known limitation

A form built with the Bootstrap grid produces one spurious `{input bootstrap_row_N}` line per row. Blueprint walks everything `$form->getControls()` yields, `BootstrapRow` must implement `Control` to appear in the renderer's own loop, and Blueprint's dummy emits an `{input …}` placeholder for whatever it wraps — so the row cannot be filtered out without either coupling to Blueprint's anonymous dummy class or reworking how rows sit in the component tree. It no longer crashes; delete the line. Happy to chase it further if you think it's worth it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)