### PR TITLE
chore: raise PHPStan to level 8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ csf: vendor
 	vendor/bin/codefixer src tests
 
 phpstan: vendor
-	vendor/bin/phpstan analyse -l 7 -c phpstan.neon src
+	vendor/bin/phpstan analyse -l 8 -c phpstan.neon src
 
 tests: vendor
 	vendor/bin/phpunit

--- a/src/BootstrapRenderer.php
+++ b/src/BootstrapRenderer.php
@@ -75,6 +75,7 @@ class BootstrapRenderer implements FormRenderer
 	 *
 	 * @param string[]|string $config top-level config key
 	 * @param Html|null $el elem to config.
+	 * @return ($el is null ? Html|null : Html)
 	 */
 	public function configElem($config, ?Html $el = null): ?Html
 	{
@@ -142,12 +143,15 @@ class BootstrapRenderer implements FormRenderer
 		// el may be null, but maybe it has a container defined
 		if (isset($config[Cnf::CONTAINER])) {
 			$container = $this->configElem($config[Cnf::CONTAINER], null);
-			if ($container !== null && $el !== null) {
-				$elClone = clone $el;
-				$container->setHtml($elClone);
-			}
+			// a container config which yields no element of its own must not swallow the element it wraps
+			if ($container !== null) {
+				if ($el !== null) {
+					$elClone = clone $el;
+					$container->setHtml($elClone);
+				}
 
-			$el = $container;
+				$el = $container;
+			}
 		}
 
 		return $el;
@@ -525,7 +529,7 @@ class BootstrapRenderer implements FormRenderer
 
 		if ($controlLabel === null) {
 			if (method_exists($control, 'allignWithInputControls') && $control->allignWithInputControls()) {
-				return $this->configElem(Cnf::LABEL, null);
+				return $this->getElem(Cnf::LABEL);
 			}
 
 			return Html::el();
@@ -545,7 +549,7 @@ class BootstrapRenderer implements FormRenderer
 	 */
 	public function renderPair(BaseControl $control): string
 	{
-		$pairHtml = $this->configElem(Cnf::PAIR);
+		$pairHtml = $this->getElem(Cnf::PAIR);
 
 		$pairHtml->id = $control->getOption(RendererOptions::ID);
 
@@ -573,9 +577,7 @@ class BootstrapRenderer implements FormRenderer
 
 		//endregion
 
-		if (!empty($nonLabel)) {
-			$pairHtml->addHtml($nonLabel);
-		}
+		$pairHtml->addHtml($nonLabel);
 
 		return $pairHtml->render(0);
 	}
@@ -627,7 +629,7 @@ class BootstrapRenderer implements FormRenderer
 	 *
 	 * @param string $additionalKeys config will be overridden in this order
 	 */
-	protected function getElem(string $key, ...$additionalKeys): ?Html
+	protected function getElem(string $key, ...$additionalKeys): Html
 	{
 		$el = $this->configElem($key, Html::el());
 

--- a/src/Grid/BootstrapCell.php
+++ b/src/Grid/BootstrapCell.php
@@ -91,7 +91,7 @@ class BootstrapCell
 		$element = $this->elementPrototype;
 
 		/** @var BootstrapRenderer $renderer */
-		$renderer = $this->row->getParent()->getForm()->getRenderer();
+		$renderer = $this->row->getContainer()->getForm()->getRenderer();
 
 		$element = $renderer->configElem(RendererConfig::GRID_CELL, $element);
 		$element->class[] = $this->createClass();

--- a/src/Grid/BootstrapRow.php
+++ b/src/Grid/BootstrapRow.php
@@ -11,6 +11,7 @@ use Nette\ComponentModel\IContainer;
 use Nette\Forms\Container;
 use Nette\Forms\Control;
 use Nette\InvalidArgumentException;
+use Nette\InvalidStateException;
 use Nette\SmartObject;
 use Nette\Utils\Html;
 
@@ -56,9 +57,9 @@ class BootstrapRow implements IComponent, Control
 	private $columnsOccupied = 0;
 
 	/**
-	 * Form or container this belong to
+	 * Form or container this belong to. Null while the row is detached.
 	 *
-	 * @var Container
+	 * @var Container|null
 	 */
 	private $container;
 
@@ -119,8 +120,13 @@ class BootstrapRow implements IComponent, Control
 	 */
 	public function addComponent(IComponent $component, ?string $name = null, ?string $insertBefore = null): void
 	{
-		$this->container->addComponent($component, $name, $insertBefore);
-		$this->ownedNames[] = $name;
+		$this->getContainer()->addComponent($component, $name, $insertBefore);
+
+		// a successful add always leaves the component named, even when no name was passed here
+		$ownedName = $name ?? $component->getName();
+		if ($ownedName !== null) {
+			$this->ownedNames[] = $ownedName;
+		}
 	}
 
 	/**
@@ -172,23 +178,41 @@ class BootstrapRow implements IComponent, Control
 	}
 
 	/**
-	 * Returns the container
-	 *
-	 * @return Container
+	 * Returns the container, or null if the row is not attached to one
 	 */
-	public function getParent(): IContainer
+	public function getParent(): ?IContainer
 	{
+		return $this->container;
+	}
+
+	/**
+	 * Returns the container this row belongs to
+	 *
+	 * @throws InvalidStateException if the row is not attached to a container
+	 */
+	public function getContainer(): Container
+	{
+		if ($this->container === null) {
+			throw new InvalidStateException('The row is not attached to a container.');
+		}
+
 		return $this->container;
 	}
 
 	/**
 	 * Sets the container
 	 *
-	 * @param Container|NULL $parent
+	 * @param Container|null $parent
 	 * @param null $name ignored
 	 */
 	public function setParent(?IContainer $parent = null, ?string $name = null): static
 	{
+		if ($parent !== null && !$parent instanceof Container) {
+			throw new InvalidArgumentException(
+				sprintf('%s can only be attached to a %s, %s given.', self::class, Container::class, $parent::class)
+			);
+		}
+
 		$this->container = $parent;
 
 		return $this;
@@ -210,7 +234,7 @@ class BootstrapRow implements IComponent, Control
 	public function render(): Html
 	{
 		/** @var BootstrapRenderer $renderer */
-		$renderer = $this->container->getForm()->getRenderer();
+		$renderer = $this->getContainer()->getForm()->getRenderer();
 
 		$element = $renderer->configElem(RendererConfig::GRID_ROW, $this->elementPrototype);
 		foreach ($this->cells as $cell) {

--- a/tests/Grid/BootstrapRowTest.php
+++ b/tests/Grid/BootstrapRowTest.php
@@ -6,6 +6,8 @@ use Contributte\FormsBootstrap\BootstrapForm;
 use Contributte\FormsBootstrap\Grid\BootstrapCell;
 use Contributte\FormsBootstrap\Grid\BootstrapRow;
 use Nette\Application\UI\Presenter;
+use Nette\InvalidArgumentException;
+use Nette\InvalidStateException;
 use Nette\NotImplementedException;
 use Tests\BaseTestCase;
 
@@ -111,6 +113,29 @@ class BootstrapRowTest extends BaseTestCase
 		$this->row->addCell(12)->addText('name', 'Name');
 
 		$this->assertSame('name', $this->form['name']->getName());
+	}
+
+	public function testDetachedRowReportsNoParent(): void
+	{
+		$this->row->setParent(null);
+
+		$this->assertNull($this->row->getParent());
+	}
+
+	public function testDetachedRowCannotBeRendered(): void
+	{
+		$this->row->setParent(null);
+
+		$this->expectException(InvalidStateException::class);
+
+		$this->row->getContainer();
+	}
+
+	public function testRowRefusesParentThatIsNotFormContainer(): void
+	{
+		$this->expectException(InvalidArgumentException::class);
+
+		$this->row->setParent($this->createStub(Presenter::class));
 	}
 
 	protected function setUp(): void


### PR DESCRIPTION
Raises the PHPStan level in `make phpstan` from 7 to 8. Level 8 checks method calls and property access on nullable types, which surfaced three real holes rather than just noise.

## What level 8 found

**`BootstrapRenderer::configElem()` could throw away the element it was configuring.**
When a config entry had a `CONTAINER` key whose own config produced no element, `$el = $container` overwrote the element with `null` and the caller silently lost it. It now only swaps in the container when there is one. That also makes the method total — given an element, it always returns one — which is expressed with a conditional return type:

```php
@return ($el is null ? Html|null : Html)
```

With that, `getElem()` is declared `: Html` instead of `: ?Html`, and its ~20 call sites across `renderBody()`, `renderPair()`, `renderFeedback()` and `renderDescription()` stop looking nullable. Two `configElem(…, null)` calls that always needed a real element were switched to `getElem()`, and a dead `!empty($nonLabel)` guard on an always-truthy `Html` object was dropped.

**`BootstrapRow::$container` was typed `Container` but could hold `null`.**
`setParent()` takes `?IContainer` and assigned straight to the property, so a detached row (or one attached to a non-`Nette\Forms\Container`) violated its own declared type. Now:

- the property is `Container|null`;
- `getParent()` returns `?IContainer`, matching `IComponent` and reality;
- `setParent()` throws `InvalidArgumentException` for a parent that is not a `Nette\Forms\Container`, instead of storing something the rest of the class cannot use;
- a new `getContainer(): Container` gives `render()`, `addComponent()` and `BootstrapCell::render()` the attached container, or an `InvalidStateException` with a clear message instead of a null-call fatal.

**`BootstrapRow::$ownedNames` was declared `string[]` but collected `?string`.**
It now records the name the component actually ends up with after the add.

## API notes

`BootstrapRow::getParent()` widened from `IContainer` to `?IContainer`. Callers that need the container should use the new `getContainer()`.

## Verification

- `make phpstan` (now `-l 8`) — no errors
- `make cs` — clean
- `make tests` — 161 tests, 245 assertions, all passing (3 new tests cover the detached-row and wrong-parent paths)

No fixture changes: rendered HTML is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)