### PR TITLE
chore: raise PHPStan to level 9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ csf: vendor
 	vendor/bin/codefixer src tests
 
 phpstan: vendor
-	vendor/bin/phpstan analyse -l 8 -c phpstan.neon src
+	vendor/bin/phpstan analyse -l 9 -c phpstan.neon src
 
 tests: vendor
 	vendor/bin/phpunit

--- a/src/BootstrapRenderer.php
+++ b/src/BootstrapRenderer.php
@@ -13,7 +13,9 @@ use Nette\Forms\Control;
 use Nette\Forms\Controls\BaseControl;
 use Nette\Forms\Form;
 use Nette\Forms\FormRenderer;
+use Nette\HtmlStringable;
 use Nette\Utils\Html;
+use Stringable;
 
 /**
  * Converts a Form into Bootstrap 4 HTML output.
@@ -21,8 +23,8 @@ use Nette\Utils\Html;
  * @property int        $mode
  * @property string     $gridBreakPoint    Bootstrap grid breakpoint for side-by-side view. Default is 'sm'.
  *           NULL means not to use a breakpoint
- * @property-read mixed[] $config
- * @property-read mixed[] $configOverride
+ * @property-read array<string, mixed[]> $config
+ * @property-read array<int, array<string, mixed[]>> $configOverride
  * @property bool       $groupHidden       if true, hidden fields will be grouped at the end. If false,
  *           hidden fields are placed where they were added. Default is true.
  */
@@ -73,19 +75,19 @@ class BootstrapRenderer implements FormRenderer
 	/**
 	 * Turns configuration or and existing element and configures it appropriately
 	 *
-	 * @param string[]|string $config top-level config key
+	 * @param mixed[]|string $config top-level config key, or the config itself
 	 * @param Html|null $el elem to config.
 	 * @return ($el is null ? Html|null : Html)
 	 */
 	public function configElem($config, ?Html $el = null): ?Html
 	{
-		if (is_scalar($config)) {
+		if (is_string($config)) {
 			$config = $this->fetchConfig($config);
 		}
 
 		// first define which element we want to work with
-		if (isset($config[Cnf::ELEMENT_NAME])) {
-			$name = $config[Cnf::ELEMENT_NAME];
+		$name = $config[Cnf::ELEMENT_NAME] ?? null;
+		if (is_string($name)) {
 			if (!$el) {
 				// element does not exist, so create it
 				$el = Html::el($name);
@@ -96,53 +98,35 @@ class BootstrapRenderer implements FormRenderer
 		}
 
 		if ($el instanceof Html) {
-			$origClass = null;
 			// go through all config and configure element accordingly
 			foreach ($config as $key => $value) {
-				if (in_array($key, [Cnf::CLASS_SET, Cnf::CLASS_ADD, Cnf::CLASS_ADD, Cnf::CLASS_REMOVE])) {
-					// we'll be working with classes, we must standardize everything to arrays, not strings for the sake of sanity
-					if (!is_array($value)) {
-						// configuration may contain classes as strings, but we always work with arrays
-						$value = [$value];
+				if (in_array($key, [Cnf::CLASS_SET, Cnf::CLASS_ADD, Cnf::CLASS_REMOVE], true)) {
+					// configuration may contain classes as strings, but we always work with arrays
+					$classes = is_array($value) ? $value : [$value];
+					$origClass = $this->fetchClasses($el);
+
+					if ($key === Cnf::CLASS_SET) {
+						$el->setAttribute('class', $classes);
+					} elseif ($key === Cnf::CLASS_ADD) {
+						$el->setAttribute('class', array_merge($origClass, $classes));
+					} else {
+						$el->setAttribute('class', array_filter(
+							$origClass,
+							static fn ($origClassName): bool => !in_array($origClassName, $classes, true)
+						));
 					}
-
-					$origClass = $el->getAttribute('class');
-					$newClass = $origClass;
-					if ($origClass === null) {
-						// class is not set
-						$newClass = [];
-					} elseif (!is_array($origClass)) {
-						// class is set, but not a array
-						$newClass = explode(' ', $el->getAttribute('class'));
-					}
-
-					$el->setAttribute('class', $newClass);
-					$origClass = $newClass;
-				}
-
-				if ($key === Cnf::CLASS_SET) {
-					$el->setAttribute('class', $value);
-				} elseif ($key === Cnf::CLASS_ADD) {
-					$el->setAttribute(
-						'class',
-						array_merge($origClass, $value)
-					);
-				} elseif ($key === Cnf::CLASS_REMOVE) {
-					$el->setAttribute(
-						'class',
-						array_diff($origClass, $value)
-					);
-				} elseif ($key === Cnf::ATTRIBUTES) {
+				} elseif ($key === Cnf::ATTRIBUTES && is_array($value)) {
 					foreach ($value as $attr => $attrVal) {
-						$el->setAttribute($attr, $attrVal);
+						$el->setAttribute((string) $attr, $attrVal);
 					}
 				}
 			}
 		}
 
 		// el may be null, but maybe it has a container defined
-		if (isset($config[Cnf::CONTAINER])) {
-			$container = $this->configElem($config[Cnf::CONTAINER], null);
+		$containerConfig = $config[Cnf::CONTAINER] ?? null;
+		if (is_array($containerConfig) || is_string($containerConfig)) {
+			$container = $this->configElem($containerConfig, null);
 			// a container config which yields no element of its own must not swallow the element it wraps
 			if ($container !== null) {
 				if ($el !== null) {
@@ -158,7 +142,7 @@ class BootstrapRenderer implements FormRenderer
 	}
 
 	/**
-	 * @return mixed[]
+	 * @return array<string, mixed[]> element config, keyed by first-level config key
 	 */
 	public function getConfig(): array
 	{
@@ -226,7 +210,7 @@ class BootstrapRenderer implements FormRenderer
 	}
 
 	/**
-	 * @return mixed[]
+	 * @return array<int, array<string, mixed[]>> element config per render mode
 	 */
 	public function getConfigOverride(): array
 	{
@@ -410,7 +394,8 @@ class BootstrapRenderer implements FormRenderer
 
 			//endregion
 
-			if (!empty($label)) {
+			// anything else the option may hold is not something we can draw
+			if ($label instanceof HtmlStringable) {
 				$container->addHtml($label);
 			}
 
@@ -614,14 +599,36 @@ class BootstrapRenderer implements FormRenderer
 	 */
 	protected function fetchConfig(string $key): array
 	{
-		$config = $this->config[$key];
+		$config = $this->getConfig()[$key];
+		$override = $this->getConfigOverride()[$this->renderMode][$key] ?? null;
 
-		if (isset($this->configOverride[$this->renderMode][$key])) {
-			$override = $this->configOverride[$this->renderMode][$key];
+		if ($override !== null) {
 			$config = array_merge($config, $override);
 		}
 
 		return $config;
+	}
+
+	/**
+	 * Reads the element's class attribute as a list of classes, whichever way it was set
+	 *
+	 * @return mixed[]
+	 */
+	protected function fetchClasses(Html $el): array
+	{
+		$class = $el->getAttribute('class');
+
+		if (is_array($class)) {
+			return $class;
+		}
+
+		// class is set, but not as an array
+		if (is_string($class)) {
+			return explode(' ', $class);
+		}
+
+		// class is not set
+		return [];
 	}
 
 	/**
@@ -702,7 +709,7 @@ class BootstrapRenderer implements FormRenderer
 				foreach ($messages as $message) {
 					if ($message instanceof Html) {
 						$el->addHtml($message);
-					} else {
+					} elseif (is_string($message) || is_int($message) || $message instanceof Stringable) {
 						$el->addText($message);
 					}
 

--- a/src/Inputs/CheckboxInput.php
+++ b/src/Inputs/CheckboxInput.php
@@ -8,6 +8,7 @@ use Contributte\FormsBootstrap\Traits\StandardValidationTrait;
 use Nette;
 use Nette\Forms\Controls\Checkbox;
 use Nette\Utils\Html;
+use Stringable;
 
 /**
  * Class CheckboxInput. Single checkbox.
@@ -32,7 +33,7 @@ class CheckboxInput extends Checkbox implements IValidationInput
 	 */
 	public bool $allignWithInputControls;
 
-	public function __construct(string|\Stringable|null $label = null)
+	public function __construct(string|Stringable|null $label = null)
 	{
 		$this->allignWithInputControls = static::$defaultAllignWithInputControls;
 
@@ -42,7 +43,7 @@ class CheckboxInput extends Checkbox implements IValidationInput
 	/**
 	 * Makes a Bootstrap checkbox HTML
 	 *
-	 * @param string|Html|null $caption
+	 * @param string|Stringable|null $caption
 	 * @param bool|mixed             $value pass false to omit
 	 */
 	public static function makeCheckbox(
@@ -92,11 +93,14 @@ class CheckboxInput extends Checkbox implements IValidationInput
 	 */
 	public function getControl(): Html
 	{
+		$caption = $this->translate($this->getCaption());
+
 		return self::makeCheckbox(
 			$this->getHtmlName(),
 			$this->getHtmlId(),
-			$this->translate($this->getCaption()),
-			$this->value,
+			is_string($caption) || $caption instanceof Stringable ? $caption : null,
+			// Checkbox::setValue() only ever stores a bool
+			(bool) $this->value,
 			false,
 			$this->required,
 			$this->disabled,

--- a/src/Inputs/CheckboxListInput.php
+++ b/src/Inputs/CheckboxListInput.php
@@ -6,6 +6,7 @@ use Contributte\FormsBootstrap\Traits\ChoiceInputTrait;
 use Contributte\FormsBootstrap\Traits\StandardValidationTrait;
 use Nette\Forms\Controls\CheckboxList;
 use Nette\Utils\Html;
+use Stringable;
 
 /**
  * Class CheckboxListInput.
@@ -36,7 +37,7 @@ class CheckboxListInput extends CheckboxList implements IValidationInput
 			$line = CheckboxInput::makeCheckbox(
 				$this->getHtmlName(),
 				$baseId . $c,
-				$caption === null ? null : (string) $caption,
+				is_scalar($caption) || $caption instanceof Stringable ? (string) $caption : null,
 				$this->isValueSelected($value),
 				$value,
 				false,

--- a/src/Inputs/DateInput.php
+++ b/src/Inputs/DateInput.php
@@ -73,7 +73,15 @@ class DateInput extends TextInput
 	{
 		assert($input instanceof self);
 
-		return DateTimeFormat::validate($input->getFormat(), $input->getValue());
+		$value = $input->getValue();
+
+		// the rule checks the text the user typed; an already parsed (or empty)
+		// value has no textual format to check, so there is nothing to reject
+		if (!is_string($value)) {
+			return true;
+		}
+
+		return DateTimeFormat::validate($input->getFormat(), $value);
 	}
 
 	/**
@@ -91,7 +99,7 @@ class DateInput extends TextInput
 	{
 		$val = parent::getValue();
 
-		if (empty($val) || !$this->isValidated) {
+		if (empty($val) || !is_string($val) || !$this->isValidated) {
 			return $val;
 		}
 

--- a/src/Inputs/RadioInput.php
+++ b/src/Inputs/RadioInput.php
@@ -10,7 +10,9 @@ use Contributte\FormsBootstrap\Traits\StandardValidationTrait;
 use Nette\Forms\Controls\ChoiceControl;
 use Nette\Forms\Controls\RadioList;
 use Nette\Forms\Helpers;
+use Nette\HtmlStringable;
 use Nette\Utils\Html;
+use Stringable;
 
 /**
  * Class RadioInput. Lets user choose one out of multiple options.
@@ -76,12 +78,20 @@ class RadioInput extends RadioList implements IValidationInput
 
 			$wrapper->addHtml($input);
 
-			$wrapper->addHtml(
-				Html::el('label', [
-					'class' => [BootstrapForm::getBootstrapVersion() === BootstrapVersion::V5 ? 'form-check-label' : 'custom-control-label'],
-					'for' => $itemHtmlId,
-				])->addHtml($this->translate($caption))
-			);
+			$label = Html::el('label', [
+				'class' => [BootstrapForm::getBootstrapVersion() === BootstrapVersion::V5 ? 'form-check-label' : 'custom-control-label'],
+				'for' => $itemHtmlId,
+			]);
+
+			$translatedCaption = $this->translate($caption);
+			if ($translatedCaption instanceof HtmlStringable || is_string($translatedCaption)) {
+				$label->addHtml($translatedCaption);
+			} elseif ($translatedCaption instanceof Stringable || is_int($translatedCaption)) {
+				// not markup, so it has to be escaped
+				$label->addText($translatedCaption);
+			}
+
+			$wrapper->addHtml($label);
 
 			$container->addHtml($wrapper);
 			$c++;

--- a/src/Traits/ChoiceInputTrait.php
+++ b/src/Traits/ChoiceInputTrait.php
@@ -2,6 +2,8 @@
 
 namespace Contributte\FormsBootstrap\Traits;
 
+use Stringable;
+
 /**
  * Trait ChoiceInputTrait.
  * Provides basic functionality for inputs where one of more than one predefined values are possible.
@@ -30,7 +32,8 @@ trait ChoiceInputTrait
 	protected function isValueDisabled($value): bool
 	{
 		$disabled = $this->disabled;
-		if (is_array($disabled)) {
+		// only something usable as an array key can be listed among the disabled values
+		if (is_array($disabled) && (is_int($value) || is_string($value))) {
 			return isset($disabled[$value]) && $disabled[$value];
 		}
 
@@ -51,7 +54,22 @@ trait ChoiceInputTrait
 			return in_array($value, $val);
 		}
 
-		return ((string) $value) === ((string) $val);
+		return $this->stringifyChoiceValue($value) === $this->stringifyChoiceValue($val);
+	}
+
+	/**
+	 * Choice values are compared the way they appear in the rendered markup — as strings
+	 *
+	 * @param mixed $value
+	 */
+	private function stringifyChoiceValue($value): string
+	{
+		if ($value === null || is_scalar($value) || $value instanceof Stringable) {
+			return (string) $value;
+		}
+
+		// nothing a choice key could ever be
+		return '';
 	}
 
 }

--- a/tests/Inputs/DateInputTest.php
+++ b/tests/Inputs/DateInputTest.php
@@ -5,6 +5,7 @@ namespace Tests\Inputs;
 use Contributte\FormsBootstrap\BootstrapForm;
 use Contributte\FormsBootstrap\Enums\DateTimeFormat;
 use Contributte\FormsBootstrap\Inputs\DateInput;
+use DateTime;
 use Nette\Forms\Form;
 use Tests\BaseTestCase;
 
@@ -46,6 +47,40 @@ class DateInputTest extends BaseTestCase
 		$this->assertStringContainsString(':equal', $rules);
 		$this->assertStringContainsString(':filled', $rules);
 		$this->assertStringContainsString(':minLength', $rules);
+	}
+
+	/**
+	 * The format rule reads the control's value, which is a DateTime once the input
+	 * has been validated. It used to hand that straight to a string parameter.
+	 */
+	public function testFormatRuleAcceptsAnAlreadyParsedValue(): void
+	{
+		$form = new BootstrapForm();
+		$date = $form->addBootstrapDate('date', 'Date');
+		$date->setValue(new DateTime());
+
+		$this->assertInstanceOf(DateTime::class, $date->getValue());
+		$this->assertTrue(DateInput::validateFormat($date));
+	}
+
+	public function testFormatRuleStillRejectsUnparseableText(): void
+	{
+		$form = new BootstrapForm();
+		$date = $form->addBootstrapDate('date', 'Date');
+		$date->setValue('not a date');
+
+		$this->assertFalse(DateInput::validateFormat($date));
+	}
+
+	public function testNullValueHasNoFormatToReject(): void
+	{
+		$form = new BootstrapForm();
+		$date = $form->addBootstrapDate('date', 'Date');
+		$date->setNullable();
+		$date->setValue(null);
+
+		$this->assertNull($date->getValue());
+		$this->assertTrue(DateInput::validateFormat($date));
 	}
 
 }

--- a/tests/Rendering/RendererConfigTest.php
+++ b/tests/Rendering/RendererConfigTest.php
@@ -47,6 +47,15 @@ class RendererConfigTest extends BaseTestCase
 		$this->assertSame('<div class="keep"></div>', (string) $el);
 	}
 
+	public function testClassConfigMayBePlainString(): void
+	{
+		$el = Html::el('div', ['class' => 'original']);
+
+		$this->renderer->configElem([Cnf::CLASS_ADD => 'extra'], $el);
+
+		$this->assertSame('<div class="original extra"></div>', (string) $el);
+	}
+
 	public function testAttributesAreApplied(): void
 	{
 		$el = Html::el('input');


### PR DESCRIPTION
Follow-up to #133. Raises the PHPStan level in `make phpstan` from 8 to 9.

Level 9 stops accepting `mixed` where a concrete type is required. Most of the 35 errors traced back to one place: the renderer's config arrays and Nette's `getOption()` / `translate()` / `getValue()` all return `mixed`, and that value was passed straight into typed APIs.

## Renderer config plumbing

- `getConfig()` / `getConfigOverride()` now declare their real shape (`array<string, mixed[]>` and `array<int, array<string, mixed[]>>`), so `fetchConfig()` returns an array rather than `mixed`. It reads them through the getters instead of the `SmartObject` magic properties — the same call, without the untyped detour.
- `configElem()` narrows what it reads out of the config instead of trusting it. A non-string element name is ignored, class config is normalized once up front, and an `attributes` entry that is not an array is skipped rather than fed to `foreach`.
- Class handling moved into a `fetchClasses()` helper. `CLASS_REMOVE` now uses a strict `array_filter` instead of `array_diff`, which insisted every class be castable to string — Nette also accepts `['class-name' => bool]` class attributes, and the filter handles those without a cast while preserving keys exactly as `array_diff` did.

## Drawing values that came from options

Group labels and validation messages are drawn only when they are actually drawable — `HtmlStringable` / `string` / `Stringable` — instead of handing whatever the option happened to hold to `addHtml()` or `addText()`. Previously a group label option holding, say, an int went to `addHtml()` unchecked.

## Inputs

- `ChoiceInputTrait` only indexes the disabled-values array with something usable as an array key, and compares choice values through a `stringifyChoiceValue()` helper instead of casting `mixed` to string.
- `CheckboxInput`, `CheckboxListInput` and `RadioInput` narrow the result of `translate()` before using it as a caption. `CheckboxInput::makeCheckbox()`'s `$caption` doc widened from `string|Html|null` to `string|Stringable|null`, which is what it always accepted — `setText()` takes `Stringable`, and `Html` is one.

## One real bug: `DateInput::validateFormat()`

This one was not just a typing gap. The rule passed `$input->getValue()` into a `string` parameter, but `getValue()` returns a `DateTime` once the input has been validated — so calling the rule in that state was a guaranteed `TypeError`:

```
TypeError: DateTimeFormat::validate(): Argument #2 ($timeString) must be of type string, DateTime given
```

It survived in practice only because `BaseControl::validate()` calls `cleanErrors()` first, which `DateInput` overrides to reset its `isValidated` flag — so during normal form validation `getValue()` still returns the raw text. Any other route to the rule crashed.

The rule now checks the format only when there is text to check, and returns `true` otherwise (an already-parsed value has no textual format to reject; emptiness is the required rule's job). `getValue()` gained the same guard before handing its value to `DateTime::createFromFormat()`.

## Verification

- `make phpstan` (now `-l 9`) — no errors
- `make cs` — clean
- `make tests` — 173 tests, 266 assertions, all passing

4 new tests: three pin the `DateInput` rule behaviour (parsed value, unparseable text, null value on a nullable input), one covers class config given as a plain string rather than an array.

Rendered HTML is unchanged — no fixture updates. The existing `RendererConfigTest` cases for `CLASS_SET` / `CLASS_ADD` / `CLASS_REMOVE` / `ATTRIBUTES` / `CONTAINER` all still pass against the rewritten `configElem()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)