### PR TITLE
chore: raise PHPStan to level 10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ csf: vendor
 	vendor/bin/codefixer src tests
 
 phpstan: vendor
-	vendor/bin/phpstan analyse -l 9 -c phpstan.neon src
+	vendor/bin/phpstan analyse -l 10 -c phpstan.neon src
 
 tests: vendor
 	vendor/bin/phpunit

--- a/src/BootstrapForm.php
+++ b/src/BootstrapForm.php
@@ -62,10 +62,7 @@ class BootstrapForm extends Form
 		]);
 		$this->elementPrototype = $prototype;
 
-		/**
-		 * @param BootstrapForm $form
-		 */
-		$this->onError[] = function ($form): void {
+		$this->onError[] = function (self $form): void {
 			$form->showValidation = $this->autoShowValidation;
 		};
 	}
@@ -161,19 +158,14 @@ class BootstrapForm extends Form
 	{
 		$this->isAjax = $isAjax;
 
-		BootstrapUtils::standardizeClass($this->getElementPrototype());
-		$prototypeClass = $this->getElementPrototype()->class;
+		$prototype = $this->getElementPrototype();
+		$present = BootstrapUtils::hasClass($prototype, $this->ajaxClass);
 
-		$present = in_array($this->ajaxClass, $prototypeClass);
 		if ($present && !$isAjax) {
-			// remove the class
-			$prototypeClass = array_diff($prototypeClass, [$this->ajaxClass]);
+			BootstrapUtils::removeClass($prototype, $this->ajaxClass);
 		} elseif (!$present && $isAjax) {
-			// add class
-			$prototypeClass[] = $this->ajaxClass;
+			BootstrapUtils::addClass($prototype, $this->ajaxClass);
 		}
-
-		$this->getElementPrototype()->class = $prototypeClass;
 
 		return $this;
 	}

--- a/src/BootstrapRenderer.php
+++ b/src/BootstrapRenderer.php
@@ -325,11 +325,12 @@ class BootstrapRenderer implements FormRenderer
 		$el = $this->configElem('form', $this->form->getElementPrototype());
 
 		if ($this->form->isMethod('get')) {
-			$el->action = (string) $el->action;
-			/** @noinspection PhpUndefinedFieldInspection */
-			$query = parse_url($el->action, PHP_URL_QUERY);
-			/** @noinspection PhpUndefinedFieldInspection */
-			$el->action = str_replace('?' . $query, '', $el->action);
+			// the action may be set as anything printable, a Nette\Application\UI\Link among others
+			$action = $el->getAttribute('action');
+			$action = is_scalar($action) || $action instanceof Stringable ? (string) $action : '';
+
+			$query = parse_url($action, PHP_URL_QUERY);
+			$el->action = str_replace('?' . $query, '', $action);
 
 			$s = '';
 			$params = ($query === null || $query === false)
@@ -616,19 +617,7 @@ class BootstrapRenderer implements FormRenderer
 	 */
 	protected function fetchClasses(Html $el): array
 	{
-		$class = $el->getAttribute('class');
-
-		if (is_array($class)) {
-			return $class;
-		}
-
-		// class is set, but not as an array
-		if (is_string($class)) {
-			return explode(' ', $class);
-		}
-
-		// class is not set
-		return [];
+		return BootstrapUtils::fetchClasses($el);
 	}
 
 	/**

--- a/src/BootstrapUtils.php
+++ b/src/BootstrapUtils.php
@@ -21,4 +21,56 @@ class BootstrapUtils
 		}
 	}
 
+	/**
+	 * Reads element classes as a list, whichever way the class attribute was set
+	 *
+	 * @return mixed[]
+	 */
+	public static function fetchClasses(Html $control): array
+	{
+		$class = $control->getAttribute('class');
+
+		if (is_array($class)) {
+			return $class;
+		}
+
+		// class is set, but not as an array
+		if (is_string($class)) {
+			return explode(' ', $class);
+		}
+
+		// class is not set
+		return [];
+	}
+
+	/**
+	 * Appends a class to the element
+	 */
+	public static function addClass(Html $control, string $class): void
+	{
+		$classes = self::fetchClasses($control);
+		$classes[] = $class;
+
+		$control->class = $classes;
+	}
+
+	/**
+	 * Removes a class from the element, if it is there at all
+	 */
+	public static function removeClass(Html $control, string $class): void
+	{
+		$control->class = array_filter(
+			self::fetchClasses($control),
+			static fn ($presentClass): bool => $presentClass !== $class
+		);
+	}
+
+	/**
+	 * Whether the element already carries the class
+	 */
+	public static function hasClass(Html $control, string $class): bool
+	{
+		return in_array($class, self::fetchClasses($control), true);
+	}
+
 }

--- a/src/Grid/BootstrapCell.php
+++ b/src/Grid/BootstrapCell.php
@@ -3,6 +3,7 @@
 namespace Contributte\FormsBootstrap\Grid;
 
 use Contributte\FormsBootstrap\BootstrapRenderer;
+use Contributte\FormsBootstrap\BootstrapUtils;
 use Contributte\FormsBootstrap\Enums\RendererConfig;
 use Contributte\FormsBootstrap\Traits\BootstrapContainerTrait;
 use Nette\ComponentModel\IComponent;
@@ -94,7 +95,7 @@ class BootstrapCell
 		$renderer = $this->row->getContainer()->getForm()->getRenderer();
 
 		$element = $renderer->configElem(RendererConfig::GRID_CELL, $element);
-		$element->class[] = $this->createClass();
+		BootstrapUtils::addClass($element, $this->createClass());
 
 		foreach ($this->childControls as $childControl) {
 			$pairHtml = $renderer->renderPair($childControl);
@@ -133,7 +134,7 @@ class BootstrapCell
 	 */
 	public function addHtmlClass(string $class)
 	{
-		$this->elementPrototype->class[] = $class;
+		BootstrapUtils::addClass($this->elementPrototype, $class);
 
 		return $this;
 	}

--- a/src/Inputs/ColorPicker.php
+++ b/src/Inputs/ColorPicker.php
@@ -14,9 +14,7 @@ class ColorPicker extends \Nette\Forms\Controls\ColorPicker implements IValidati
 	public function getControl(): Html
 	{
 		$control = parent::getControl();
-		BootstrapUtils::standardizeClass($control);
-
-		$control->class[] = 'form-control';
+		BootstrapUtils::addClass($control, 'form-control');
 
 		return $control;
 	}

--- a/src/Inputs/DateInput.php
+++ b/src/Inputs/DateInput.php
@@ -2,6 +2,7 @@
 
 namespace Contributte\FormsBootstrap\Inputs;
 
+use Contributte\FormsBootstrap\BootstrapUtils;
 use Contributte\FormsBootstrap\Enums\DateTimeFormat;
 use DateTime;
 use DateTimeInterface;
@@ -160,7 +161,7 @@ class DateInput extends TextInput
 	public function getControl(): Html
 	{
 		$control = parent::getControl();
-		$control->class[] = implode(' ', static::$additionalHtmlClasses);
+		BootstrapUtils::addClass($control, implode(' ', static::$additionalHtmlClasses));
 
 		return $control;
 	}

--- a/src/Inputs/DateTimeControl.php
+++ b/src/Inputs/DateTimeControl.php
@@ -14,9 +14,7 @@ class DateTimeControl extends \Nette\Forms\Controls\DateTimeControl implements I
 	public function getControl(): Html
 	{
 		$control = parent::getControl();
-		BootstrapUtils::standardizeClass($control);
-
-		$control->class[] = 'form-control';
+		BootstrapUtils::addClass($control, 'form-control');
 
 		return $control;
 	}

--- a/src/Inputs/TextAreaInput.php
+++ b/src/Inputs/TextAreaInput.php
@@ -52,9 +52,7 @@ class TextAreaInput extends TextArea implements IValidationInput, IAutocompleteI
 	public function getControl(): Html
 	{
 		$control = parent::getControl();
-		BootstrapUtils::standardizeClass($control);
-
-		$control->class[] = 'form-control';
+		BootstrapUtils::addClass($control, 'form-control');
 		if ($this->autocomplete !== null) {
 			$control->setAttribute('autocomplete', $this->autocomplete ? 'on' : 'off');
 		}

--- a/src/Inputs/TextInput.php
+++ b/src/Inputs/TextInput.php
@@ -64,9 +64,7 @@ class TextInput extends \Nette\Forms\Controls\TextInput implements IValidationIn
 	public function getControl(): Html
 	{
 		$control = parent::getControl();
-		BootstrapUtils::standardizeClass($control);
-
-		$control->class[] = 'form-control';
+		BootstrapUtils::addClass($control, 'form-control');
 		if (!empty($this->placeholder)) {
 			$control->setAttribute('placeholder', $this->placeholder);
 		}

--- a/src/Inputs/UploadInput.php
+++ b/src/Inputs/UploadInput.php
@@ -4,6 +4,7 @@ namespace Contributte\FormsBootstrap\Inputs;
 
 use Contributte\FormsBootstrap\BootstrapForm;
 use Contributte\FormsBootstrap\BootstrapRenderer;
+use Contributte\FormsBootstrap\BootstrapUtils;
 use Contributte\FormsBootstrap\Enums\BootstrapVersion;
 use Contributte\FormsBootstrap\Enums\RendererConfig;
 use Nette\Application\UI\Form;
@@ -49,7 +50,10 @@ class UploadInput extends UploadControl implements IValidationInput
 	{
 		/** @var Html $control */
 		$control = parent::getControl();
-		$control->class = trim($control->class .= BootstrapForm::getBootstrapVersion() === BootstrapVersion::V5 ? ' form-control' : ' custom-file-input');
+		BootstrapUtils::addClass(
+			$control,
+			BootstrapForm::getBootstrapVersion() === BootstrapVersion::V5 ? 'form-control' : 'custom-file-input'
+		);
 
 		$el = Html::el('div', ['class' => [BootstrapForm::getBootstrapVersion() === BootstrapVersion::V5 ? null : 'custom-file']]);
 		$el->addHtml($control);

--- a/src/Traits/BootstrapButtonTrait.php
+++ b/src/Traits/BootstrapButtonTrait.php
@@ -73,8 +73,7 @@ trait BootstrapButtonTrait
 
 	protected function addBtnClass(Html $element): void
 	{
-		BootstrapUtils::standardizeClass($element);
-		$element->class[] = 'btn ' . $this->getBtnClass();
+		BootstrapUtils::addClass($element, 'btn ' . $this->getBtnClass());
 	}
 
 }

--- a/src/Traits/BootstrapContainerTrait.php
+++ b/src/Traits/BootstrapContainerTrait.php
@@ -35,6 +35,7 @@ use Nette\Forms\Controls\TextArea;
 use Nette\Forms\Controls\TextInput as NetteTextInput;
 use Nette\Forms\Controls\UploadControl;
 use Nette\Forms\Form;
+use Nette\InvalidArgumentException;
 use Nette\Utils\Html;
 
 /**
@@ -201,7 +202,15 @@ trait BootstrapContainerTrait
 	 */
 	public function addInputError(string $componentName, string $message): void
 	{
-		$this->getComponent($componentName)->addError($message);
+		$component = $this->getComponent($componentName);
+
+		if (!$component instanceof BaseControl) {
+			throw new InvalidArgumentException(
+				sprintf('Component "%s" is not a form control, so it cannot carry an error.', $componentName)
+			);
+		}
+
+		$component->addError($message);
 	}
 
 	/**

--- a/tests/BootstrapFormTest.php
+++ b/tests/BootstrapFormTest.php
@@ -65,6 +65,16 @@ class BootstrapFormTest extends BaseTestCase
 		$this->assertNotContains('ajax', $form->getElementPrototype()->class);
 	}
 
+	public function testAjaxClassIsNotAddedTwice(): void
+	{
+		$form = new BootstrapForm();
+
+		$form->setAjax(true);
+		$form->setAjax(true);
+
+		$this->assertSame(['ajax'], $form->getElementPrototype()->class);
+	}
+
 	public function testGetRendererReturnsTheBootstrapRenderer(): void
 	{
 		$form = new BootstrapForm();

--- a/tests/BootstrapUtilsTest.php
+++ b/tests/BootstrapUtilsTest.php
@@ -15,4 +15,55 @@ class BootstrapUtilsTest extends BaseTestCase
 		$this->assertEquals(['c1', 'c2'], $html->class);
 	}
 
+	public function testFetchClassesReadsEitherShapeOfTheAttribute(): void
+	{
+		$this->assertSame(['c1', 'c2'], BootstrapUtils::fetchClasses(Html::el('div', ['class' => 'c1 c2'])));
+		$this->assertSame(['c1', 'c2'], BootstrapUtils::fetchClasses(Html::el('div', ['class' => ['c1', 'c2']])));
+		$this->assertSame([], BootstrapUtils::fetchClasses(Html::el('div')));
+	}
+
+	public function testAddClassKeepsWhateverWasThere(): void
+	{
+		$html = Html::el('div', ['class' => 'c1 c2']);
+
+		BootstrapUtils::addClass($html, 'c3');
+
+		$this->assertSame('<div class="c1 c2 c3"></div>', (string) $html);
+	}
+
+	public function testAddClassOnElementWithoutOne(): void
+	{
+		$html = Html::el('div');
+
+		BootstrapUtils::addClass($html, 'only');
+
+		$this->assertSame('<div class="only"></div>', (string) $html);
+	}
+
+	public function testRemoveClassDropsOnlyTheNamedOne(): void
+	{
+		$html = Html::el('div', ['class' => 'keep drop']);
+
+		BootstrapUtils::removeClass($html, 'drop');
+
+		$this->assertSame('<div class="keep"></div>', (string) $html);
+	}
+
+	public function testRemoveClassThatIsNotThereChangesNothing(): void
+	{
+		$html = Html::el('div', ['class' => 'keep']);
+
+		BootstrapUtils::removeClass($html, 'absent');
+
+		$this->assertSame('<div class="keep"></div>', (string) $html);
+	}
+
+	public function testHasClass(): void
+	{
+		$html = Html::el('div', ['class' => 'c1 c2']);
+
+		$this->assertTrue(BootstrapUtils::hasClass($html, 'c1'));
+		$this->assertFalse(BootstrapUtils::hasClass($html, 'c3'));
+	}
+
 }

--- a/tests/Traits/BootstrapContainerTraitTest.php
+++ b/tests/Traits/BootstrapContainerTraitTest.php
@@ -6,6 +6,7 @@ use Contributte\FormsBootstrap\BootstrapForm;
 use Contributte\FormsBootstrap\Inputs\DateTimeControl;
 use Contributte\FormsBootstrap\Inputs\TextInput;
 use Contributte\FormsBootstrap\Inputs\UploadInput;
+use Nette\InvalidArgumentException;
 use Tests\BaseTestCase;
 
 /**
@@ -150,6 +151,16 @@ class BootstrapContainerTraitTest extends BaseTestCase
 
 		$this->assertSame(['that name is taken'], $form['name']->getErrors());
 		$this->assertTrue($form->hasErrors());
+	}
+
+	public function testAddInputErrorRejectsComponentThatIsNotControl(): void
+	{
+		$form = new BootstrapForm();
+		$form->addContainer('sub');
+
+		$this->expectException(InvalidArgumentException::class);
+
+		$form->addInputError('sub', 'nowhere to put this');
 	}
 
 	public function testAddColorProducesColorInput(): void


### PR DESCRIPTION
Follow-up to #134, and the last step — 10 is PHPStan's maximum level. It treats *implicit* `mixed` the same way level 9 treats explicit `mixed`.

All 17 errors had the same origin: reading back through Nette's magic accessors, which are `mixed` by nature.

## The `class[]` idiom, in one place

Nine of the errors were `$el->class[] = '...'` — spread across seven files, each preceded (or, in two cases, *not* preceded) by its own `BootstrapUtils::standardizeClass()` call. It worked because Nette's `Html::__get()` returns by reference, so the append auto-vivified the attribute.

`BootstrapUtils` now carries that knowledge instead:

```php
BootstrapUtils::fetchClasses($el);       // classes as a list, however the attribute was set
BootstrapUtils::addClass($el, 'form-control');
BootstrapUtils::removeClass($el, 'ajax');
BootstrapUtils::hasClass($el, 'ajax');
```

Call sites now read as what they do. `BootstrapRenderer::fetchClasses()`, which #134 added, was this same logic a second time and now delegates to the util. `standardizeClass()` is kept — it is public API — though nothing in `src/` needs it any more.

## The rest

- **`BootstrapForm::setAjax()`** did the class juggling by hand (`standardizeClass` → read → `in_array` → `array_diff` → write back). It goes through the util now and keeps its "only add if absent" behaviour, which a new test pins down.
- **The `onError` handler** took an untyped `$form` with `@param BootstrapForm $form` in a docblock positioned where PHPStan could not attach it. It is a real parameter type now.
- **`renderBegin()`** read `$el->action` three times, casting `mixed` to string and carrying two `@noinspection` comments. It reads the attribute once into a local and normalizes it there — which also handles an action set as a `Nette\Application\UI\Link` rather than a plain string.
- **`addInputError()`** called `addError()` on whatever `getComponent()` returned. It now checks for a `BaseControl` and throws `InvalidArgumentException` naming the component when given something that cannot hold an error (a container, say), instead of dying on an undefined method.
- **`UploadInput`** loses `trim($control->class .= ...)`, which relied on the class attribute being a string *and* on `.=` evaluated inside a function call.

## Verification

- `make phpstan` (now `-l 10`, the maximum) — no errors
- `make cs` — clean
- `make tests` — 181 tests, 277 assertions, all passing

8 new tests: six cover the new `BootstrapUtils` methods (both attribute shapes, absent attribute, removing a class that is not there), one that `setAjax(true)` twice does not duplicate the class, one for the `addInputError` guard.

Rendered HTML is unchanged — no fixture updates. The snapshot suite is the safety net for the `class[]` refactor: every one of those seven files feeds into fixtures that still match byte for byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)